### PR TITLE
feat(icon): replace plugin icon with a winding path mark

### DIFF
--- a/src/main/resources/META-INF/pluginIcon.svg
+++ b/src/main/resources/META-INF/pluginIcon.svg
@@ -1,12 +1,16 @@
 <svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <path d="M32.0845 7.94025V4H24.0203V7.9896H16.029V4H7.91553V7.94025H4V36H16.0044V32.0045C16.0058 30.9457 16.4274 29.9308 17.1766 29.1826C17.9258 28.4345 18.9412 28.0143 20 28.0143C21.0588 28.0143 22.0743 28.4345 22.8234 29.1826C23.5726 29.9308 23.9942 30.9457 23.9956 32.0045V36H36V7.94025H32.0845Z"
-          fill="url(#paint0_linear)"/>
     <defs>
-        <linearGradient id="paint0_linear" x1="2.94192" y1="4.89955" x2="37.7772" y2="39.7345"
-                        gradientUnits="userSpaceOnUse">
-            <stop offset="0.15937" stop-color="#3BEA62"/>
-            <stop offset="0.5404" stop-color="#3C99CC"/>
-            <stop offset="0.93739" stop-color="#6B57FF"/>
+        <linearGradient id="walkthroughPath" x1="4" y1="4" x2="36" y2="36" gradientUnits="userSpaceOnUse">
+            <stop offset="0" stop-color="#B59CFF"/>
+            <stop offset="1" stop-color="#5638D6"/>
         </linearGradient>
     </defs>
+    <path d="M 8 8 C 30 8, 30 20, 20 20 C 10 20, 10 32, 32 32"
+          stroke="url(#walkthroughPath)"
+          stroke-width="3"
+          stroke-linecap="round"
+          fill="none"/>
+    <circle cx="8" cy="8" r="3.5" fill="url(#walkthroughPath)"/>
+    <circle cx="20" cy="20" r="3.5" fill="url(#walkthroughPath)"/>
+    <circle cx="32" cy="32" r="3.5" fill="url(#walkthroughPath)"/>
 </svg>


### PR DESCRIPTION
## Solution

The current icon is the placeholder gradient house left over from the IntelliJ Platform Template. This swaps it for a purple winding-path SVG that fits the plugin: a single S-curve linking three waypoint dots in a `#B59CFF → #5638D6` gradient.

It reads as a stepped journey through code at 40×40, scales to retina sizes, and stays visible on both light and dark IDE backgrounds. No text, no template defaults, no resemblance to JetBrains or competitor logos.

## Test plan

- [x] Run `just run` and check the icon in the Plugins panel at default (16×16) and larger preview (40×40) sizes
- [x] Switch between Light and Dark themes in the sandbox IDE and confirm the icon stays readable on both
