### PR TITLE
fix(popup): throttle walkthrough animation to ~15 Hz

### DIFF
--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupContent.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupContent.kt
@@ -1,11 +1,5 @@
 package com.forketyfork.walkthrough
 
-import androidx.compose.animation.core.LinearEasing
-import androidx.compose.animation.core.RepeatMode
-import androidx.compose.animation.core.animateFloat
-import androidx.compose.animation.core.infiniteRepeatable
-import androidx.compose.animation.core.rememberInfiniteTransition
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.LocalScrollbarStyle
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.ScrollbarStyle
@@ -47,6 +41,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.intellij.openapi.project.Project
+import kotlinx.coroutines.delay
 import org.jetbrains.jewel.ui.component.Text
 
 private object WalkthroughPopupContentStyle {
@@ -61,6 +56,11 @@ private object WalkthroughPopupContentStyle {
     const val ANIMATION_END = 1f
     const val GRADIENT_ANIMATION_DURATION_MS = 5400
     const val GLOW_ANIMATION_DURATION_MS = 3200
+
+    // Drives shift updates via a manual coroutine instead of Compose's frame clock, so the
+    // SkiaLayer (and the editor underneath the translucent popup corners) only repaints at
+    // this cadence. Lower values save more CPU at the cost of visible stepping.
+    const val ANIMATION_FRAME_INTERVAL_MS = 67L
     val backgroundGradientColors = listOf(
         WalkthroughColors.veryDarkPurple,
         WalkthroughColors.darkPurple,
@@ -170,30 +170,24 @@ private fun rememberPopupAnimationState(): WalkthroughPopupAnimationState {
             )
         }
     }
-    val transition = rememberInfiniteTransition()
-    val gradientShift by transition.animateFloat(
-        initialValue = WalkthroughPopupContentStyle.ANIMATION_START,
-        targetValue = WalkthroughPopupContentStyle.ANIMATION_END,
-        animationSpec = infiniteRepeatable(
-            animation = tween(
-                durationMillis = WalkthroughPopupContentStyle.GRADIENT_ANIMATION_DURATION_MS,
-                easing = LinearEasing
-            ),
-            repeatMode = RepeatMode.Reverse
-        )
-    )
-    val glowShift by transition.animateFloat(
-        initialValue = WalkthroughPopupContentStyle.ANIMATION_START,
-        targetValue = WalkthroughPopupContentStyle.ANIMATION_END,
-        animationSpec = infiniteRepeatable(
-            animation = tween(
-                durationMillis = WalkthroughPopupContentStyle.GLOW_ANIMATION_DURATION_MS,
-                easing = LinearEasing
-            ),
-            repeatMode = RepeatMode.Reverse
-        )
-    )
+    var gradientShift by remember { mutableStateOf(WalkthroughPopupContentStyle.ANIMATION_START) }
+    var glowShift by remember { mutableStateOf(WalkthroughPopupContentStyle.ANIMATION_START) }
+    LaunchedEffect(Unit) {
+        val startTime = System.currentTimeMillis()
+        while (true) {
+            val elapsed = System.currentTimeMillis() - startTime
+            gradientShift = reverseLinearShift(elapsed, WalkthroughPopupContentStyle.GRADIENT_ANIMATION_DURATION_MS)
+            glowShift = reverseLinearShift(elapsed, WalkthroughPopupContentStyle.GLOW_ANIMATION_DURATION_MS)
+            delay(WalkthroughPopupContentStyle.ANIMATION_FRAME_INTERVAL_MS)
+        }
+    }
     return WalkthroughPopupAnimationState(gradientShift = gradientShift, glowShift = glowShift)
+}
+
+private fun reverseLinearShift(elapsedMs: Long, halfPeriodMs: Int): Float {
+    val period = 2L * halfPeriodMs
+    val phase = (elapsedMs % period).toFloat() / halfPeriodMs.toFloat()
+    return if (phase < 1f) phase else 2f - phase
 }
 
 @Composable

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupContent.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupContent.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.intellij.openapi.project.Project
 import kotlinx.coroutines.delay
+import kotlin.time.TimeSource
 import org.jetbrains.jewel.ui.component.Text
 
 private object WalkthroughPopupContentStyle {
@@ -173,21 +174,15 @@ private fun rememberPopupAnimationState(): WalkthroughPopupAnimationState {
     var gradientShift by remember { mutableStateOf(WalkthroughPopupContentStyle.ANIMATION_START) }
     var glowShift by remember { mutableStateOf(WalkthroughPopupContentStyle.ANIMATION_START) }
     LaunchedEffect(Unit) {
-        val startTime = System.currentTimeMillis()
+        val mark = TimeSource.Monotonic.markNow()
         while (true) {
-            val elapsed = System.currentTimeMillis() - startTime
+            val elapsed = mark.elapsedNow().inWholeMilliseconds
             gradientShift = reverseLinearShift(elapsed, WalkthroughPopupContentStyle.GRADIENT_ANIMATION_DURATION_MS)
             glowShift = reverseLinearShift(elapsed, WalkthroughPopupContentStyle.GLOW_ANIMATION_DURATION_MS)
             delay(WalkthroughPopupContentStyle.ANIMATION_FRAME_INTERVAL_MS)
         }
     }
     return WalkthroughPopupAnimationState(gradientShift = gradientShift, glowShift = glowShift)
-}
-
-private fun reverseLinearShift(elapsedMs: Long, halfPeriodMs: Int): Float {
-    val period = 2L * halfPeriodMs
-    val phase = (elapsedMs % period).toFloat() / halfPeriodMs.toFloat()
-    return if (phase < 1f) phase else 2f - phase
 }
 
 @Composable

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupGeometry.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupGeometry.kt
@@ -169,3 +169,9 @@ internal fun cubicEaseInOut(progress: Float): Float =
 
 internal fun lerp(start: Float, end: Float, progress: Float): Float =
     start + (end - start) * progress
+
+internal fun reverseLinearShift(elapsedMs: Long, halfPeriodMs: Int): Float {
+    val period = 2L * halfPeriodMs
+    val phase = (elapsedMs % period).toFloat() / halfPeriodMs.toFloat()
+    return if (phase < 1f) phase else 2f - phase
+}

--- a/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughPopupGeometryTest.kt
+++ b/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughPopupGeometryTest.kt
@@ -77,4 +77,49 @@ class WalkthroughPopupGeometryTest {
         val lateProgress = cubicEaseInOut(0.9f)
         assertTrue(lateProgress > 0.9f, "Expected slow end: f(0.9)=$lateProgress should be > 0.9")
     }
+
+    @Test
+    fun reverseLinearShiftStartsAtZero() {
+        assertEquals(0f, reverseLinearShift(0L, 1000), 0.001f)
+    }
+
+    @Test
+    fun reverseLinearShiftPeaksAtHalfPeriod() {
+        assertEquals(1f, reverseLinearShift(1000L, 1000), 0.001f)
+    }
+
+    @Test
+    fun reverseLinearShiftReturnsToZeroAtFullPeriod() {
+        assertEquals(0f, reverseLinearShift(2000L, 1000), 0.001f)
+    }
+
+    @Test
+    fun reverseLinearShiftStaysInUnitInterval() {
+        val halfPeriod = 1000
+        for (t in 0..4000 step 50) {
+            val v = reverseLinearShift(t.toLong(), halfPeriod)
+            assertTrue(v in 0f..1f, "Expected value in [0,1] at t=$t, got $v")
+        }
+    }
+
+    @Test
+    fun reverseLinearShiftIsSymmetricAroundHalfPeriod() {
+        val halfPeriod = 1000
+        for (t in 0..1000 step 50) {
+            val before = reverseLinearShift(t.toLong(), halfPeriod)
+            val after = reverseLinearShift((2 * halfPeriod - t).toLong(), halfPeriod)
+            assertEquals(before, after, 0.001f, "Expected symmetry around half-period at t=$t")
+        }
+    }
+
+    @Test
+    fun reverseLinearShiftRepeatsEachPeriod() {
+        val halfPeriod = 1000
+        val period = 2 * halfPeriod
+        for (t in 0..period step 50) {
+            val first = reverseLinearShift(t.toLong(), halfPeriod)
+            val nextCycle = reverseLinearShift((t + period).toLong(), halfPeriod)
+            assertEquals(first, nextCycle, 0.001f, "Expected periodicity at t=$t")
+        }
+    }
 }


### PR DESCRIPTION
## Solution

The walkthrough popup's animated gradient and glow were keeping the EDT and the Java2D Metal queue near 50% utilization. JFR profiling traced this to `rememberInfiniteTransition`: while it had a running animation, Compose Desktop's frame clock kept pumping frames at vsync rate. Each frame the SkiaLayer painted even when no draw cache had invalidated, and Swing repainted the editor underneath the popup's translucent corners along with it. An earlier attempt to quantize the animated values via `derivedStateOf` removed the per-frame Skia shader rebuilds (gradient construction dropped from 6 hits to 0 across the JFR window) but left the per-frame paint cycle intact, since the frame clock keeps ticking regardless of whether downstream content invalidates.

This change drops the Compose `Transition` API and instead drives the two shift values from a `LaunchedEffect` loop that calls `delay(67)` (≈ 15 Hz). Position is computed manually as a triangle wave (equivalent to `RepeatMode.Reverse` with `LinearEasing`). Without an animation observer registered, the frame clock no longer pumps speculative frames, so Compose only renders when the shift state actually changes.

JFR comparison across three captures (per-second rates):

| Bucket | Before | After |
|---|---|---|
| EDT total samples | 18 / s | 2.2 / s |
| Compose / Skia render samples | 4.4 / s | 0.33 / s |
| Editor.paint samples | 5.2 / s | 0.33 / s |
| Java2D Queue Flusher | 5.6 / s | 0.25 / s |

`ANIMATION_FRAME_INTERVAL_MS = 67L` is exposed as a tunable constant. Bumping it to 33L recovers roughly 30 Hz if the visible stepping is too coarse.

## Test plan

- [x] Open a project with a walkthrough item (e.g. via the MCP tool) and watch the gradient and glow animate. Stepping should be subtle but visible.
- [x] Leave the popup open for several minutes and confirm the IDE's CPU usage stays low.
- [x] Cycle through walkthrough items via Previous and Next and confirm the animation continues smoothly across item changes.
- [x] Resize the IDE window and scroll the editor while the popup is open; the popup should stay anchored and the animation should not stutter.
