### PR TITLE
Add per-project walkthrough history (#9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,12 @@ line, and lets the user step through a sequence of walkthrough items.
 ## Features
 
 - An MCP tool, `show_walkthrough_items`, that accepts JSON input and displays one or more
-  walkthrough items.
+  walkthrough items with a description for history.
 - Optional file and line navigation for each item, so a walkthrough can jump to the right place
   before rendering.
 - Previous and Next navigation inside the popup for multi-step walkthroughs.
+- Per-project walkthrough history stored under `.idea/walkthroughs/`, with a keymap-bindable
+  action for replaying previous walkthroughs.
 - A Compose-based popup UI rendered through Jewel on the IntelliJ Platform.
 
 ## Prerequisites

--- a/src/main/kotlin/com/forketyfork/walkthrough/ResolvedWalkthroughTarget.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/ResolvedWalkthroughTarget.kt
@@ -23,7 +23,8 @@ internal fun resolveWalkthroughTarget(
     val fileEditorManager = FileEditorManager.getInstance(project)
     val fileTarget = item.file
         ?.let { relativePath -> resolveFileTarget(project, fileEditorManager, item, relativePath) }
-    return fileTarget ?: resolveFallbackTarget(fileEditorManager, fallbackEditor, item)
+    val fallbackItem = if (item.file != null && fileTarget == null) item.withFallbackAnchor() else item
+    return fileTarget ?: resolveFallbackTarget(fileEditorManager, fallbackEditor, fallbackItem)
 }
 
 private fun resolveFallbackTarget(
@@ -58,8 +59,8 @@ private fun resolveFileTarget(
 }
 
 private fun findWalkthroughFile(project: Project, relativePath: String) =
-    project.basePath
-        ?.let { "$it/$relativePath" }
+    resolveProjectRelativeWalkthroughPath(project.basePath, relativePath)
+        ?.toString()
         ?.let(LocalFileSystem.getInstance()::findFileByPath)
 
 private fun VirtualFile.lineCount(): Int? =

--- a/src/main/kotlin/com/forketyfork/walkthrough/ResolvedWalkthroughTarget.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/ResolvedWalkthroughTarget.kt
@@ -1,0 +1,85 @@
+package com.forketyfork.walkthrough
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.LogicalPosition
+import com.intellij.openapi.editor.ScrollType
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.fileEditor.OpenFileDescriptor
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.VirtualFile
+
+internal data class ResolvedWalkthroughTarget(
+    val editor: Editor,
+    val popupItem: WalkthroughItem
+)
+
+internal fun resolveWalkthroughTarget(
+    project: Project,
+    fallbackEditor: Editor?,
+    item: WalkthroughItem
+): ResolvedWalkthroughTarget? {
+    val fileEditorManager = FileEditorManager.getInstance(project)
+    val fileTarget = item.file
+        ?.let { relativePath -> resolveFileTarget(project, fileEditorManager, item, relativePath) }
+    return fileTarget ?: resolveFallbackTarget(fileEditorManager, fallbackEditor, item)
+}
+
+private fun resolveFallbackTarget(
+    fileEditorManager: FileEditorManager,
+    fallbackEditor: Editor?,
+    item: WalkthroughItem
+): ResolvedWalkthroughTarget? {
+    val editor = fileEditorManager.selectedTextEditor ?: fallbackEditor ?: return null
+    val popupItem = if (isResolvableWalkthroughLine(item.line, editor.document.lineCount)) {
+        moveCaretToLine(editor, item.line)
+        item
+    } else {
+        item.withFallbackAnchor()
+    }
+    return ResolvedWalkthroughTarget(editor, popupItem)
+}
+
+private fun resolveFileTarget(
+    project: Project,
+    fileEditorManager: FileEditorManager,
+    item: WalkthroughItem,
+    relativePath: String
+): ResolvedWalkthroughTarget? {
+    val virtualFile = findWalkthroughFile(project, relativePath)
+    val lineCount = virtualFile?.lineCount()
+    val editor = if (virtualFile != null && lineCount != null && isResolvableWalkthroughLine(item.line, lineCount)) {
+        openEditor(project, fileEditorManager, virtualFile, item)
+    } else {
+        null
+    }
+    return editor?.let { ResolvedWalkthroughTarget(it, item) }
+}
+
+private fun findWalkthroughFile(project: Project, relativePath: String) =
+    project.basePath
+        ?.let { "$it/$relativePath" }
+        ?.let(LocalFileSystem.getInstance()::findFileByPath)
+
+private fun VirtualFile.lineCount(): Int? =
+    FileDocumentManager.getInstance().getDocument(this)?.lineCount
+
+private fun openEditor(
+    project: Project,
+    fileEditorManager: FileEditorManager,
+    virtualFile: VirtualFile,
+    item: WalkthroughItem
+): Editor? {
+    val lineIndex = (item.line ?: 1).coerceAtLeast(1) - 1
+    return runCatching {
+        fileEditorManager.openTextEditor(OpenFileDescriptor(project, virtualFile, lineIndex, 0), true)
+    }.getOrNull()
+}
+
+private fun moveCaretToLine(editor: Editor, line: Int?) {
+    if (line == null) return
+    val lineIndex = line - 1
+    editor.caretModel.moveToLogicalPosition(LogicalPosition(lineIndex, 0))
+    editor.scrollingModel.scrollToCaret(ScrollType.CENTER)
+}

--- a/src/main/kotlin/com/forketyfork/walkthrough/ShowWalkthroughItemsToolset.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/ShowWalkthroughItemsToolset.kt
@@ -67,8 +67,9 @@ class ShowWalkthroughItemsToolset : McpToolset {
 
         val record = WalkthroughHistoryService.getInstance(project)
             .save(trimmedDescription, itemList)
-            ?: mcpFail("Project path is required to save walkthrough history")
 
-        return "Walkthrough items shown and saved as ${record.id}"
+        return record
+            ?.let { savedRecord -> "Walkthrough items shown and saved as ${savedRecord.id}" }
+            ?: "Walkthrough items shown; history was not saved"
     }
 }

--- a/src/main/kotlin/com/forketyfork/walkthrough/ShowWalkthroughItemsToolset.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/ShowWalkthroughItemsToolset.kt
@@ -9,13 +9,6 @@ import com.intellij.mcpserver.annotations.McpTool
 import com.intellij.mcpserver.mcpFail
 import com.intellij.mcpserver.projectOrNull
 import com.intellij.openapi.application.EDT
-import com.intellij.openapi.editor.Editor
-import com.intellij.openapi.editor.LogicalPosition
-import com.intellij.openapi.editor.ScrollType
-import com.intellij.openapi.fileEditor.FileEditorManager
-import com.intellij.openapi.fileEditor.OpenFileDescriptor
-import com.intellij.openapi.project.Project
-import com.intellij.openapi.vfs.LocalFileSystem
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.withContext
@@ -27,11 +20,15 @@ class ShowWalkthroughItemsToolset : McpToolset {
     @Suppress("unused")
     @McpTool(name = "show_walkthrough_items")
     @McpDescription(
-        "Shows walkthrough items with navigation support. " +
+        "Shows and stores walkthrough items with navigation support. " +
             "Accepts one or more walkthrough items; the user can cycle through them " +
-            "with Previous and Next buttons."
+            "with Previous and Next buttons. The walkthrough is saved to this project's history."
     )
     suspend fun showWalkthroughItems(
+        @McpDescription(
+            "Short human-readable description shown in the project walkthrough history. " +
+            "Use a concise phrase that helps the user recognize this walkthrough later."
+        ) description: String,
         @McpDescription(
             "JSON array of walkthrough items to display, e.g. " +
             "[{\"text\":\"Note 1\",\"file\":\"src/Foo.kt\",\"line\":10},{\"text\":\"Note 2\"}]. " +
@@ -42,6 +39,8 @@ class ShowWalkthroughItemsToolset : McpToolset {
     ): String {
         val project = currentCoroutineContext().projectOrNull
             ?: mcpFail("No active project")
+        val trimmedDescription = description.trim()
+        if (trimmedDescription.isBlank()) mcpFail("description must not be blank")
 
         val itemList = try {
             val type = object : TypeToken<List<WalkthroughItemJson>>() {}.type
@@ -62,48 +61,14 @@ class ShowWalkthroughItemsToolset : McpToolset {
         if (itemList.isEmpty()) mcpFail("items must not be empty")
 
         val shown = withContext(Dispatchers.EDT) {
-            val firstItem = itemList.first()
-            val editor = navigateAndGetEditor(project, firstItem)
-
-            if (editor != null) {
-                showWalkthroughItems(project, editor, itemList)
-                true
-            } else {
-                false
-            }
+            showWalkthroughItems(project, itemList)
         }
+        if (!shown) mcpFail("No active editor")
 
-        return if (shown) "Walkthrough items shown" else mcpFail("No active editor")
+        val record = WalkthroughHistoryService.getInstance(project)
+            .save(trimmedDescription, itemList)
+            ?: mcpFail("Project path is required to save walkthrough history")
+
+        return "Walkthrough items shown and saved as ${record.id}"
     }
-}
-
-private fun navigateAndGetEditor(project: Project, item: WalkthroughItem): Editor? {
-    val fileEditorManager = FileEditorManager.getInstance(project)
-    return item.file
-        ?.let { relativePath -> openReferencedEditor(project, fileEditorManager, item, relativePath) }
-        ?: moveCaretIfNeeded(fileEditorManager.selectedTextEditor, item.line)
-}
-
-private fun openReferencedEditor(
-    project: Project,
-    fileEditorManager: FileEditorManager,
-    item: WalkthroughItem,
-    relativePath: String
-): Editor? {
-    val virtualFile = findReferencedFile(project, relativePath) ?: return null
-    val lineIndex = (item.line ?: 1) - 1
-    return fileEditorManager.openTextEditor(OpenFileDescriptor(project, virtualFile, lineIndex, 0), true)
-}
-
-private fun findReferencedFile(project: Project, relativePath: String) =
-    project.basePath
-        ?.let { "$it/$relativePath" }
-        ?.let(LocalFileSystem.getInstance()::findFileByPath)
-
-private fun moveCaretIfNeeded(editor: Editor?, line: Int?): Editor? {
-    if (editor != null && line != null) {
-        editor.caretModel.moveToLogicalPosition(LogicalPosition(line - 1, 0))
-        editor.scrollingModel.scrollToCaret(ScrollType.CENTER)
-    }
-    return editor
 }

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughAnchorFallback.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughAnchorFallback.kt
@@ -1,0 +1,7 @@
+package com.forketyfork.walkthrough
+
+internal fun isResolvableWalkthroughLine(line: Int?, lineCount: Int): Boolean =
+    line == null || line in 1..lineCount.coerceAtLeast(1)
+
+internal fun WalkthroughItem.withFallbackAnchor(): WalkthroughItem =
+    copy(line = null)

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughAnchorFallback.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughAnchorFallback.kt
@@ -1,7 +1,23 @@
 package com.forketyfork.walkthrough
 
+import java.nio.file.Path
+
 internal fun isResolvableWalkthroughLine(line: Int?, lineCount: Int): Boolean =
     line == null || line in 1..lineCount.coerceAtLeast(1)
 
 internal fun WalkthroughItem.withFallbackAnchor(): WalkthroughItem =
-    copy(line = null)
+    copy(file = null, line = null)
+
+internal fun resolveProjectRelativeWalkthroughPath(basePath: String?, relativePath: String): Path? =
+    runCatching {
+        val base = basePath
+            ?.takeIf { value -> value.isNotBlank() }
+            ?.let { value -> Path.of(value).toAbsolutePath().normalize() }
+            ?: return@runCatching null
+        val candidate = Path.of(relativePath)
+        if (candidate.isAbsolute) return@runCatching null
+
+        base.resolve(candidate)
+            .normalize()
+            .takeIf { path -> path.startsWith(base) }
+    }.getOrNull()

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughHistoryAction.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughHistoryAction.kt
@@ -1,0 +1,65 @@
+package com.forketyfork.walkthrough
+
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.DefaultActionGroup
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.popup.JBPopupFactory
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+
+class WalkthroughHistoryAction : AnAction() {
+    override fun update(event: AnActionEvent) {
+        event.presentation.isEnabledAndVisible = event.project != null
+    }
+
+    override fun actionPerformed(event: AnActionEvent) {
+        val project = event.project ?: return
+        val records = WalkthroughHistoryService.getInstance(project).list()
+        if (records.isEmpty()) {
+            JBPopupFactory.getInstance()
+                .createMessage("No walkthrough history for this project")
+                .showInBestPositionFor(event.dataContext)
+            return
+        }
+
+        val actionGroup = DefaultActionGroup().apply {
+            records.forEach { record ->
+                add(ReplayWalkthroughAction(project, record))
+            }
+        }
+        JBPopupFactory.getInstance()
+            .createActionGroupPopup(
+                "Walkthrough History",
+                actionGroup,
+                event.dataContext,
+                JBPopupFactory.ActionSelectionAid.SPEEDSEARCH,
+                true
+            )
+            .showInBestPositionFor(event.dataContext)
+    }
+}
+
+private class ReplayWalkthroughAction(
+    private val project: Project,
+    private val record: WalkthroughRecord
+) : AnAction(formatRecord(record)) {
+    override fun actionPerformed(event: AnActionEvent) {
+        val shown = showWalkthroughItems(project, record.items)
+        if (!shown) {
+            JBPopupFactory.getInstance()
+                .createMessage("No active editor for walkthrough replay")
+                .showInBestPositionFor(event.dataContext)
+        }
+    }
+}
+
+private fun formatRecord(record: WalkthroughRecord): String {
+    val timestamp = recordDisplayFormatter.format(record.createdAtInstantOrEpoch())
+    return "$timestamp - ${record.description}"
+}
+
+private val recordDisplayFormatter = DateTimeFormatter
+    .ofLocalizedDateTime(FormatStyle.SHORT)
+    .withZone(ZoneId.systemDefault())

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughHistoryService.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughHistoryService.kt
@@ -1,0 +1,34 @@
+package com.forketyfork.walkthrough
+
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.project.Project
+import java.nio.file.Path
+
+class WalkthroughHistoryService(private val project: Project) {
+    private val store: WalkthroughHistoryStore? by lazy {
+        project.basePath?.let { basePath ->
+            WalkthroughHistoryStore(
+                directory = Path.of(basePath, ".idea", "walkthroughs"),
+                onCorruptFile = { path, exception ->
+                    LOG.warn("Skipping corrupt walkthrough history file: $path", exception)
+                }
+            )
+        }
+    }
+
+    fun save(description: String, items: List<WalkthroughItem>): WalkthroughRecord? =
+        store?.save(description, items)
+
+    fun list(): List<WalkthroughRecord> =
+        store?.list().orEmpty()
+
+    fun load(id: String): WalkthroughRecord? =
+        store?.load(id)
+
+    companion object {
+        private val LOG = Logger.getInstance(WalkthroughHistoryService::class.java)
+
+        fun getInstance(project: Project): WalkthroughHistoryService =
+            project.getService(WalkthroughHistoryService::class.java)
+    }
+}

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughHistoryService.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughHistoryService.kt
@@ -17,13 +17,25 @@ class WalkthroughHistoryService(private val project: Project) {
     }
 
     fun save(description: String, items: List<WalkthroughItem>): WalkthroughRecord? =
-        store?.save(description, items)
+        runHistoryOperation(operation = "save walkthrough history", fallback = null) {
+            store?.save(description, items)
+        }
 
     fun list(): List<WalkthroughRecord> =
-        store?.list().orEmpty()
+        runHistoryOperation(operation = "list walkthrough history", fallback = emptyList()) {
+            store?.list().orEmpty()
+        }
 
     fun load(id: String): WalkthroughRecord? =
-        store?.load(id)
+        runHistoryOperation(operation = "load walkthrough history", fallback = null) {
+            store?.load(id)
+        }
+
+    private fun <T> runHistoryOperation(operation: String, fallback: T, block: () -> T): T =
+        runCatching(block).getOrElse { exception ->
+            LOG.warn("Failed to $operation", exception)
+            fallback
+        }
 
     companion object {
         private val LOG = Logger.getInstance(WalkthroughHistoryService::class.java)

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughHistoryStore.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughHistoryStore.kt
@@ -1,0 +1,184 @@
+package com.forketyfork.walkthrough
+
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import com.google.gson.JsonParseException
+import java.io.IOException
+import java.nio.file.AtomicMoveNotSupportedException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption.ATOMIC_MOVE
+import java.nio.file.StandardCopyOption.REPLACE_EXISTING
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+import java.util.UUID
+
+private const val MAX_SLUG_LENGTH = 48
+private const val RANDOM_SUFFIX_LENGTH = 8
+private const val RECORD_EXTENSION = ".json"
+private const val INDEX_FILE_NAME = "index.json"
+private val recordIdPattern = Regex("[A-Za-z0-9._-]+")
+private val slugSeparatorPattern = Regex("[^a-z0-9]+")
+private val recordTimestampFormatter = DateTimeFormatter
+    .ofPattern("yyyyMMdd-HHmmss-SSS")
+    .withZone(ZoneOffset.UTC)
+
+private data class WalkthroughRecordJson(
+    val id: String?,
+    val createdAt: String?,
+    val description: String?,
+    val items: List<WalkthroughRecordItemJson>?
+)
+
+private data class WalkthroughRecordItemJson(
+    val text: String?,
+    val file: String?,
+    val line: Int?
+)
+
+internal class WalkthroughHistoryStore(
+    private val directory: Path,
+    private val clock: Clock = Clock.systemUTC(),
+    private val randomSuffix: () -> String = { UUID.randomUUID().toString().take(RANDOM_SUFFIX_LENGTH) },
+    private val onCorruptFile: (Path, Exception) -> Unit = { _, _ -> }
+) {
+    private val gson: Gson = GsonBuilder()
+        .disableHtmlEscaping()
+        .setPrettyPrinting()
+        .create()
+
+    fun save(description: String, items: List<WalkthroughItem>): WalkthroughRecord {
+        require(description.isNotBlank()) { "description must not be blank" }
+        require(items.isNotEmpty()) { "items must not be empty" }
+
+        val createdAt = clock.instant()
+        val record = WalkthroughRecord(
+            id = createRecordId(createdAt, description),
+            createdAt = createdAt.toString(),
+            description = description,
+            items = items
+        )
+        save(record)
+        return record
+    }
+
+    fun save(record: WalkthroughRecord) {
+        validateRecord(record)
+        Files.createDirectories(directory)
+        val target = recordPath(record.id)
+        val temporary = directory.resolve("${record.id}.tmp")
+        Files.writeString(temporary, gson.toJson(record))
+        try {
+            Files.move(temporary, target, ATOMIC_MOVE, REPLACE_EXISTING)
+        } catch (_: AtomicMoveNotSupportedException) {
+            Files.move(temporary, target, REPLACE_EXISTING)
+        }
+    }
+
+    fun list(): List<WalkthroughRecord> {
+        if (!Files.isDirectory(directory)) return emptyList()
+
+        return Files.list(directory).use { paths ->
+            paths
+                .filter(::isRecordFile)
+                .map { path -> readRecordOrNull(path) }
+                .toList()
+                .filterNotNull()
+                .sortedWith(
+                    compareByDescending<WalkthroughRecord> { record -> record.createdAtInstantOrEpoch() }
+                        .thenByDescending { record -> record.id }
+                )
+        }
+    }
+
+    fun load(id: String): WalkthroughRecord? {
+        val path = id
+            .takeIf(::isSafeRecordId)
+            ?.let(::recordPath)
+            ?.takeIf { candidate -> Files.isRegularFile(candidate) }
+        return path?.let(::readRecordOrNull)
+    }
+
+    private fun createRecordId(createdAt: Instant, description: String): String {
+        val timestamp = recordTimestampFormatter.format(createdAt)
+        val slug = slugifyDescription(description).ifBlank { "walkthrough" }
+        val suffix = randomSuffix().takeIf { it.isNotBlank() }
+            ?: UUID.randomUUID().toString().take(RANDOM_SUFFIX_LENGTH)
+        return "$timestamp-$slug-$suffix"
+    }
+
+    private fun recordPath(id: String): Path = directory.resolve("$id$RECORD_EXTENSION")
+
+    private fun isRecordFile(path: Path): Boolean {
+        val fileName = path.fileName.toString()
+        return Files.isRegularFile(path) &&
+            fileName.endsWith(RECORD_EXTENSION) &&
+            fileName != INDEX_FILE_NAME
+    }
+
+    private fun readRecordOrNull(path: Path): WalkthroughRecord? =
+        try {
+            gson.fromJson(Files.readString(path), WalkthroughRecordJson::class.java)
+                ?.toRecord()
+                ?: throw JsonParseException("Invalid walkthrough history record")
+        } catch (exception: JsonParseException) {
+            onCorruptFile(path, exception)
+            null
+        } catch (exception: IOException) {
+            onCorruptFile(path, exception)
+            null
+        } catch (exception: IllegalStateException) {
+            onCorruptFile(path, exception)
+            null
+        }
+
+    private fun validateRecord(record: WalkthroughRecord) {
+        val hasValidCreatedAt = runCatching { Instant.parse(record.createdAt) }.isSuccess
+        val hasValidFields = isSafeRecordId(record.id) &&
+            record.description.isNotBlank() &&
+            record.items.isNotEmpty() &&
+            record.items.all { item -> item.text.isNotBlank() }
+
+        if (!hasValidCreatedAt || !hasValidFields) {
+            throw JsonParseException("Invalid walkthrough history record")
+        }
+    }
+}
+
+internal fun slugifyDescription(description: String): String =
+    slugSeparatorPattern
+        .replace(description.lowercase(Locale.US), "-")
+        .trim('-')
+        .take(MAX_SLUG_LENGTH)
+        .trim('-')
+
+private fun isSafeRecordId(id: String): Boolean =
+    id.isNotBlank() && recordIdPattern.matches(id)
+
+private fun WalkthroughRecordJson.toRecord(): WalkthroughRecord? {
+    val parsedId = id?.takeIf(::isSafeRecordId)
+    val parsedCreatedAt = createdAt?.takeIf { value -> runCatching { Instant.parse(value) }.isSuccess }
+    val parsedDescription = description?.takeIf { value -> value.isNotBlank() }
+    val parsedItems = items?.mapNotNull { item -> item.toWalkthroughItemOrNull() }
+    val hasRequiredFields = parsedId != null && parsedCreatedAt != null && parsedDescription != null
+    val hasMatchingItems = parsedItems != null && parsedItems.size == items.size && parsedItems.isNotEmpty()
+
+    return if (hasRequiredFields && hasMatchingItems) {
+        WalkthroughRecord(
+            id = parsedId.orEmpty(),
+            createdAt = parsedCreatedAt.orEmpty(),
+            description = parsedDescription.orEmpty(),
+            items = parsedItems.orEmpty()
+        )
+    } else {
+        null
+    }
+}
+
+private fun WalkthroughRecordItemJson.toWalkthroughItemOrNull(): WalkthroughItem? =
+    text
+        ?.takeIf { value -> value.isNotBlank() }
+        ?.let { value -> WalkthroughItem(text = value, file = file, line = line) }

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughHistoryStore.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughHistoryStore.kt
@@ -4,7 +4,9 @@ import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import com.google.gson.JsonParseException
 import java.io.IOException
+import java.io.UncheckedIOException
 import java.nio.file.AtomicMoveNotSupportedException
+import java.nio.file.DirectoryIteratorException
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardCopyOption.ATOMIC_MOVE
@@ -81,16 +83,30 @@ internal class WalkthroughHistoryStore(
     fun list(): List<WalkthroughRecord> {
         if (!Files.isDirectory(directory)) return emptyList()
 
-        return Files.list(directory).use { paths ->
-            paths
-                .filter(::isRecordFile)
-                .map { path -> readRecordOrNull(path) }
-                .toList()
-                .filterNotNull()
-                .sortedWith(
-                    compareByDescending<WalkthroughRecord> { record -> record.createdAtInstantOrEpoch() }
-                        .thenByDescending { record -> record.id }
-                )
+        return try {
+            Files.list(directory).use { paths ->
+                paths
+                    .filter(::isRecordFile)
+                    .map { path -> readRecordOrNull(path) }
+                    .toList()
+                    .filterNotNull()
+                    .sortedWith(
+                        compareByDescending<WalkthroughRecord> { record -> record.createdAtInstantOrEpoch() }
+                            .thenByDescending { record -> record.id }
+                    )
+            }
+        } catch (exception: DirectoryIteratorException) {
+            onCorruptFile(directory, exception)
+            emptyList()
+        } catch (exception: IOException) {
+            onCorruptFile(directory, exception)
+            emptyList()
+        } catch (exception: SecurityException) {
+            onCorruptFile(directory, exception)
+            emptyList()
+        } catch (exception: UncheckedIOException) {
+            onCorruptFile(directory, exception)
+            emptyList()
         }
     }
 

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughOrchestrator.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughOrchestrator.kt
@@ -3,29 +3,34 @@ package com.forketyfork.walkthrough
 import androidx.compose.runtime.mutableStateOf
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.editor.Editor
-import com.intellij.openapi.editor.LogicalPosition
-import com.intellij.openapi.editor.ScrollType
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.FileEditorManagerEvent
 import com.intellij.openapi.fileEditor.FileEditorManagerListener
-import com.intellij.openapi.fileEditor.OpenFileDescriptor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
-import com.intellij.openapi.vfs.LocalFileSystem
 import org.jetbrains.jewel.bridge.JewelComposePanel
 import java.awt.Color as AwtColor
 import java.awt.Dimension
 import javax.swing.JComponent
 import javax.swing.SwingUtilities
 
-fun showWalkthroughItems(project: Project, editor: Editor, items: List<WalkthroughItem>) {
-    if (items.isEmpty()) return
+fun showWalkthroughItems(project: Project, items: List<WalkthroughItem>): Boolean {
+    val fallbackEditor = FileEditorManager.getInstance(project).selectedTextEditor
+    val target = items.firstOrNull()
+        ?.let { item -> resolveWalkthroughTarget(project, fallbackEditor, item) }
+    return target?.let { resolved -> showWalkthroughItems(project, resolved.editor, items) } ?: false
+}
+
+fun showWalkthroughItems(project: Project, editor: Editor, items: List<WalkthroughItem>): Boolean {
+    val firstTarget = items.firstOrNull()
+        ?.let { item -> resolveWalkthroughTarget(project, editor, item) }
+        ?: return false
     val paletteState = mutableStateOf(WalkthroughSettings.getInstance().selectedPalette)
     val sessionDisposable = Disposer.newCheckedDisposable("WalkthroughPopupSession")
     Disposer.register(project, sessionDisposable)
 
     var popupRef: WalkthroughPopupSurface? = null
-    var currentEditor = editor
+    var currentEditor = firstTarget.editor
     var pendingNavigationId = 0
 
     fun repaintPopup() {
@@ -47,10 +52,11 @@ fun showWalkthroughItems(project: Project, editor: Editor, items: List<Walkthrou
 
     fun showItem(item: WalkthroughItem) {
         val popup = popupRef ?: return
-        currentEditor = navigateToItem(project, currentEditor, item)
-        popup.update(currentEditor, item)
+        val target = resolveWalkthroughTarget(project, currentEditor, item) ?: return
+        currentEditor = target.editor
+        popup.update(currentEditor, target.popupItem)
         popup.connectorHidden = false
-        movePopupNearItem(popup, currentEditor, item, ::repaintPopup)
+        movePopupNearItem(popup, currentEditor, target.popupItem, ::repaintPopup)
     }
 
     fun scheduleItemNavigation(item: WalkthroughItem) {
@@ -109,8 +115,9 @@ fun showWalkthroughItems(project: Project, editor: Editor, items: List<Walkthrou
     )
     popupRef = popup
     Disposer.register(sessionDisposable, popup)
-    popup.update(currentEditor, items.first())
-    movePopupNearItem(popup, currentEditor, items.first(), ::repaintPopup)
+    popup.update(currentEditor, firstTarget.popupItem)
+    movePopupNearItem(popup, currentEditor, firstTarget.popupItem, ::repaintPopup)
+    return true
 }
 
 private fun createWalkthroughPanel(
@@ -140,35 +147,3 @@ private fun createWalkthroughPanel(
         )
         preferredSize = WalkthroughPopupLayout.fallbackSize
     }
-
-private fun navigateToItem(project: Project, fallbackEditor: Editor, item: WalkthroughItem): Editor {
-    val fileEditorManager = FileEditorManager.getInstance(project)
-    return item.file
-        ?.let { relativePath -> openItemEditor(project, fileEditorManager, item, relativePath) }
-        ?: moveCaretToItemLine(fileEditorManager.selectedTextEditor ?: fallbackEditor, item.line)
-}
-
-private fun openItemEditor(
-    project: Project,
-    fileEditorManager: FileEditorManager,
-    item: WalkthroughItem,
-    relativePath: String
-): Editor? {
-    val virtualFile = findWalkthroughFile(project, relativePath) ?: return null
-    val lineIndex = (item.line ?: 1).coerceAtLeast(1) - 1
-    return fileEditorManager.openTextEditor(OpenFileDescriptor(project, virtualFile, lineIndex, 0), true)
-}
-
-private fun findWalkthroughFile(project: Project, relativePath: String) =
-    project.basePath
-        ?.let { "$it/$relativePath" }
-        ?.let(LocalFileSystem.getInstance()::findFileByPath)
-
-private fun moveCaretToItemLine(editor: Editor, line: Int?): Editor {
-    if (line != null) {
-        val logicalLine = (line - 1).coerceIn(0, editor.document.lineCount - 1)
-        editor.caretModel.moveToLogicalPosition(LogicalPosition(logicalLine, 0))
-        editor.scrollingModel.scrollToCaret(ScrollType.CENTER)
-    }
-    return editor
-}

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughRecord.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughRecord.kt
@@ -1,0 +1,13 @@
+package com.forketyfork.walkthrough
+
+import java.time.Instant
+
+data class WalkthroughRecord(
+    val id: String,
+    val createdAt: String,
+    val description: String,
+    val items: List<WalkthroughItem>
+)
+
+internal fun WalkthroughRecord.createdAtInstantOrEpoch(): Instant =
+    runCatching { Instant.parse(createdAt) }.getOrDefault(Instant.EPOCH)

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -29,6 +29,7 @@
          Read more: https://plugins.jetbrains.com/docs/intellij/plugin-extension-points.html -->
     <extensions defaultExtensionNs="com.intellij">
         <applicationService serviceImplementation="com.forketyfork.walkthrough.WalkthroughSettings"/>
+        <projectService serviceImplementation="com.forketyfork.walkthrough.WalkthroughHistoryService"/>
         <applicationConfigurable
                 parentId="tools"
                 instance="com.forketyfork.walkthrough.WalkthroughSettingsConfigurable"
@@ -39,4 +40,15 @@
     <extensions defaultExtensionNs="com.intellij.mcpServer">
         <mcpToolset implementation="com.forketyfork.walkthrough.ShowWalkthroughItemsToolset"/>
     </extensions>
+
+    <actions>
+        <group id="com.forketyfork.walkthrough.Group" text="Walkthrough" popup="true">
+            <add-to-group group-id="ToolsMenu" anchor="last"/>
+            <action
+                id="com.forketyfork.walkthrough.ShowHistory"
+                class="com.forketyfork.walkthrough.WalkthroughHistoryAction"
+                text="Show Walkthrough History"
+                description="Show previous walkthroughs for the current project"/>
+        </group>
+    </actions>
 </idea-plugin>

--- a/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughAnchorFallbackTest.kt
+++ b/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughAnchorFallbackTest.kt
@@ -2,8 +2,10 @@ package com.forketyfork.walkthrough
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import java.nio.file.Path
 
 class WalkthroughAnchorFallbackTest {
     @Test
@@ -27,13 +29,33 @@ class WalkthroughAnchorFallbackTest {
     fun missingFileFallsBackToCurrentCaretAnchor() {
         val item = WalkthroughItem(text = "Step", file = "missing/File.kt", line = 10)
 
-        assertEquals(item.copy(line = null), item.withFallbackAnchor())
+        assertEquals(item.copy(file = null, line = null), item.withFallbackAnchor())
     }
 
     @Test
     fun movedFileFallsBackToCurrentCaretAnchor() {
         val item = WalkthroughItem(text = "Step", file = "old/path/File.kt", line = 42)
 
-        assertEquals(item.copy(line = null), item.withFallbackAnchor())
+        assertEquals(item.copy(file = null, line = null), item.withFallbackAnchor())
+    }
+
+    @Test
+    fun relativeProjectPathStaysUnderBasePath() {
+        val base = Path.of("/project").toAbsolutePath().normalize()
+
+        assertEquals(
+            base.resolve("src/Foo.kt"),
+            resolveProjectRelativeWalkthroughPath(base.toString(), "src/Foo.kt")
+        )
+    }
+
+    @Test
+    fun absoluteWalkthroughPathIsRejected() {
+        assertNull(resolveProjectRelativeWalkthroughPath("/project", "/etc/passwd"))
+    }
+
+    @Test
+    fun pathTraversalOutsideProjectIsRejected() {
+        assertNull(resolveProjectRelativeWalkthroughPath("/project", "../other/Foo.kt"))
     }
 }

--- a/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughAnchorFallbackTest.kt
+++ b/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughAnchorFallbackTest.kt
@@ -1,0 +1,39 @@
+package com.forketyfork.walkthrough
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class WalkthroughAnchorFallbackTest {
+    @Test
+    fun nullLineResolvesToCurrentCaret() {
+        assertTrue(isResolvableWalkthroughLine(line = null, lineCount = 20))
+    }
+
+    @Test
+    fun lineInsideDocumentResolves() {
+        assertTrue(isResolvableWalkthroughLine(line = 1, lineCount = 20))
+        assertTrue(isResolvableWalkthroughLine(line = 20, lineCount = 20))
+    }
+
+    @Test
+    fun lineOutsideDocumentIsTreatedAsStale() {
+        assertFalse(isResolvableWalkthroughLine(line = 0, lineCount = 20))
+        assertFalse(isResolvableWalkthroughLine(line = 21, lineCount = 20))
+    }
+
+    @Test
+    fun missingFileFallsBackToCurrentCaretAnchor() {
+        val item = WalkthroughItem(text = "Step", file = "missing/File.kt", line = 10)
+
+        assertEquals(item.copy(line = null), item.withFallbackAnchor())
+    }
+
+    @Test
+    fun movedFileFallsBackToCurrentCaretAnchor() {
+        val item = WalkthroughItem(text = "Step", file = "old/path/File.kt", line = 42)
+
+        assertEquals(item.copy(line = null), item.withFallbackAnchor())
+    }
+}

--- a/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughHistoryStoreTest.kt
+++ b/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughHistoryStoreTest.kt
@@ -1,0 +1,83 @@
+package com.forketyfork.walkthrough
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+
+class WalkthroughHistoryStoreTest {
+    @TempDir
+    lateinit var tempDir: Path
+
+    @Test
+    fun saveListAndLoadRoundTripWalkthroughRecord() {
+        val store = WalkthroughHistoryStore(
+            directory = tempDir,
+            clock = Clock.fixed(Instant.parse("2026-05-09T04:34:00Z"), ZoneOffset.UTC),
+            randomSuffix = { "abc12345" }
+        )
+        val items = listOf(
+            WalkthroughItem(
+                text = "Explain popup placement",
+                file = "src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupPlacement.kt",
+                line = 13
+            )
+        )
+
+        val saved = store.save("Explain popup placement", items)
+
+        assertEquals("20260509-043400-000-explain-popup-placement-abc12345", saved.id)
+        assertEquals("2026-05-09T04:34:00Z", saved.createdAt)
+        assertEquals("Explain popup placement", saved.description)
+        assertEquals(items, saved.items)
+        assertTrue(Files.isRegularFile(tempDir.resolve("${saved.id}.json")))
+        assertEquals(listOf(saved), store.list())
+        assertEquals(saved, store.load(saved.id))
+    }
+
+    @Test
+    fun listSortsNewestFirstAndSkipsCorruptFiles() {
+        val corruptFiles = mutableListOf<Path>()
+        val store = WalkthroughHistoryStore(
+            directory = tempDir,
+            onCorruptFile = { path, _ -> corruptFiles.add(path) }
+        )
+        val items = listOf(WalkthroughItem(text = "Step"))
+        val older = WalkthroughRecord(
+            id = "older",
+            createdAt = "2026-05-09T04:30:00Z",
+            description = "Older",
+            items = items
+        )
+        val newer = WalkthroughRecord(
+            id = "newer",
+            createdAt = "2026-05-09T04:35:00Z",
+            description = "Newer",
+            items = items
+        )
+        store.save(older)
+        store.save(newer)
+        Files.writeString(tempDir.resolve("corrupt.json"), "{")
+
+        assertEquals(listOf("newer", "older"), store.list().map { record -> record.id })
+        assertEquals(listOf(tempDir.resolve("corrupt.json")), corruptFiles)
+    }
+
+    @Test
+    fun loadReturnsNullForUnsafeIds() {
+        val store = WalkthroughHistoryStore(directory = tempDir)
+
+        assertEquals(null, store.load("../other-project"))
+    }
+
+    @Test
+    fun slugifyKeepsFileNamesInspectable() {
+        assertEquals("explain-popup-placement", slugifyDescription("Explain popup placement"))
+        assertEquals("", slugifyDescription("!!!"))
+    }
+}


### PR DESCRIPTION
Closes #9.

Adds per-project walkthrough history under `.idea/walkthroughs/`, with one JSON file per walkthrough and an IDE action users can bind in Keymap. The MCP tool now requires a concise `description`, saves shown walkthroughs, and the replay path reuses the existing popup flow.

Stale anchors are best-effort: missing files or invalid lines fall back to the current editor/caret instead of throwing. Corrupt history files are skipped when listing.

Verification:
- `just lint`
- `just test`
- `just build`