### PR TITLE
Add selectable popup color palettes (#8)

### DIFF
--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughOrchestrator.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughOrchestrator.kt
@@ -1,5 +1,7 @@
 package com.forketyfork.walkthrough
 
+import androidx.compose.runtime.mutableStateOf
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.LogicalPosition
 import com.intellij.openapi.editor.ScrollType
@@ -18,7 +20,7 @@ import javax.swing.SwingUtilities
 
 fun showWalkthroughItems(project: Project, editor: Editor, items: List<WalkthroughItem>) {
     if (items.isEmpty()) return
-    val palette = WalkthroughSettings.getInstance().selectedPalette
+    val paletteState = mutableStateOf(WalkthroughSettings.getInstance().selectedPalette)
     val sessionDisposable = Disposer.newCheckedDisposable("WalkthroughPopupSession")
     Disposer.register(project, sessionDisposable)
 
@@ -30,6 +32,16 @@ fun showWalkthroughItems(project: Project, editor: Editor, items: List<Walkthrou
         popupRef?.let { popup ->
             popup.refreshBounds()
             popup.repaint()
+        }
+    }
+
+    fun updatePopupPalette(palette: WalkthroughPalette) {
+        SwingUtilities.invokeLater {
+            if (sessionDisposable.isDisposed) {
+                return@invokeLater
+            }
+            paletteState.value = palette
+            popupRef?.updatePalette(palette)
         }
     }
 
@@ -55,7 +67,7 @@ fun showWalkthroughItems(project: Project, editor: Editor, items: List<Walkthrou
     val panel = createWalkthroughPanel(
         project = project,
         items = items,
-        palette = palette,
+        paletteProvider = { paletteState.value },
         onItemDisplayed = ::scheduleItemNavigation,
         onNavigateToSource = ::scheduleItemNavigation,
         onClose = { popupRef?.cancel() }
@@ -78,10 +90,18 @@ fun showWalkthroughItems(project: Project, editor: Editor, items: List<Walkthrou
             }
         }
     )
+    ApplicationManager.getApplication().messageBus.connect(sessionDisposable).subscribe(
+        WalkthroughSettingsListener.TOPIC,
+        object : WalkthroughSettingsListener {
+            override fun paletteChanged(palette: WalkthroughPalette) {
+                updatePopupPalette(palette)
+            }
+        }
+    )
 
     val popup = WalkthroughPopupSurface(
         content = panel,
-        palette = palette,
+        palette = paletteState.value,
         onCloseRequested = {
             popupRef = null
             Disposer.dispose(sessionDisposable)
@@ -96,7 +116,7 @@ fun showWalkthroughItems(project: Project, editor: Editor, items: List<Walkthrou
 private fun createWalkthroughPanel(
     project: Project,
     items: List<WalkthroughItem>,
-    palette: WalkthroughPalette,
+    paletteProvider: () -> WalkthroughPalette,
     onItemDisplayed: (WalkthroughItem) -> Unit,
     onNavigateToSource: (WalkthroughItem) -> Unit,
     onClose: () -> Unit
@@ -105,7 +125,7 @@ private fun createWalkthroughPanel(
         WalkthroughItemContent(
             project = project,
             items = items,
-            palette = palette,
+            palette = paletteProvider(),
             onItemDisplayed = onItemDisplayed,
             onNavigateToSource = onNavigateToSource,
             onClose = onClose

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughOrchestrator.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughOrchestrator.kt
@@ -18,6 +18,7 @@ import javax.swing.SwingUtilities
 
 fun showWalkthroughItems(project: Project, editor: Editor, items: List<WalkthroughItem>) {
     if (items.isEmpty()) return
+    val palette = WalkthroughSettings.getInstance().selectedPalette
     val sessionDisposable = Disposer.newCheckedDisposable("WalkthroughPopupSession")
     Disposer.register(project, sessionDisposable)
 
@@ -54,6 +55,7 @@ fun showWalkthroughItems(project: Project, editor: Editor, items: List<Walkthrou
     val panel = createWalkthroughPanel(
         project = project,
         items = items,
+        palette = palette,
         onItemDisplayed = ::scheduleItemNavigation,
         onNavigateToSource = ::scheduleItemNavigation,
         onClose = { popupRef?.cancel() }
@@ -79,6 +81,7 @@ fun showWalkthroughItems(project: Project, editor: Editor, items: List<Walkthrou
 
     val popup = WalkthroughPopupSurface(
         content = panel,
+        palette = palette,
         onCloseRequested = {
             popupRef = null
             Disposer.dispose(sessionDisposable)
@@ -93,6 +96,7 @@ fun showWalkthroughItems(project: Project, editor: Editor, items: List<Walkthrou
 private fun createWalkthroughPanel(
     project: Project,
     items: List<WalkthroughItem>,
+    palette: WalkthroughPalette,
     onItemDisplayed: (WalkthroughItem) -> Unit,
     onNavigateToSource: (WalkthroughItem) -> Unit,
     onClose: () -> Unit
@@ -101,6 +105,7 @@ private fun createWalkthroughPanel(
         WalkthroughItemContent(
             project = project,
             items = items,
+            palette = palette,
             onItemDisplayed = onItemDisplayed,
             onNavigateToSource = onNavigateToSource,
             onClose = onClose

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPalette.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPalette.kt
@@ -1,0 +1,185 @@
+package com.forketyfork.walkthrough
+
+import androidx.compose.ui.graphics.Color
+import java.awt.Color as AwtColor
+
+internal data class WalkthroughPalette(
+    val id: String,
+    val displayName: String,
+    val backgroundGradientColors: List<Color>,
+    val glowGradientColors: List<Color>,
+    val overlayColor: Color,
+    val borderGradientColors: List<Color>,
+    val scrollbarUnhoverColor: Color,
+    val scrollbarHoverColor: Color,
+    val metaTextColor: Color,
+    val badgeGradientColors: List<Color>,
+    val navPrimaryGradientColors: List<Color>,
+    val navPrimaryBorderColor: Color,
+    val connectorStrokeColor: AwtColor,
+    val connectorArrowFillColor: AwtColor
+) {
+    val swatchGradientColors: List<Color> = borderGradientColors
+}
+
+internal object WalkthroughPalettes {
+    val PURPLE = WalkthroughPalette(
+        id = "purple",
+        displayName = "Purple",
+        backgroundGradientColors = listOf(
+            WalkthroughColors.veryDarkPurple,
+            WalkthroughColors.darkPurple,
+            WalkthroughColors.magenta,
+            WalkthroughColors.navyBlue
+        ),
+        glowGradientColors = listOf(
+            WalkthroughColors.lightPink.copy(alpha = 0.4f),
+            WalkthroughColors.glowLavender,
+            Color.Transparent
+        ),
+        overlayColor = WalkthroughColors.overlay,
+        borderGradientColors = listOf(
+            WalkthroughColors.purple,
+            WalkthroughColors.pink,
+            WalkthroughColors.blue,
+            WalkthroughColors.purple
+        ),
+        scrollbarUnhoverColor = WalkthroughColors.scrollbarIndigo,
+        scrollbarHoverColor = WalkthroughColors.pink,
+        metaTextColor = WalkthroughColors.textMeta,
+        badgeGradientColors = listOf(
+            WalkthroughColors.purple,
+            WalkthroughColors.pink,
+            WalkthroughColors.blue
+        ),
+        navPrimaryGradientColors = listOf(
+            WalkthroughColors.purple,
+            WalkthroughColors.pink,
+            WalkthroughColors.deepPurple
+        ),
+        navPrimaryBorderColor = WalkthroughColors.lightPink,
+        connectorStrokeColor = AwtColor(255, 136, 136, 235),
+        connectorArrowFillColor = AwtColor(255, 102, 102, 215)
+    )
+
+    val GREEN = palette(
+        id = "green",
+        displayName = "Green",
+        darkest = Color(0xFF031F16),
+        dark = Color(0xFF064E3B),
+        mid = Color(0xFF10B981),
+        accent = Color(0xFF86EFAC),
+        alternate = Color(0xFF14B8A6),
+        glow = Color(0xFF6EE7B7),
+        meta = Color(0xFFD1FAE5),
+        connectorStroke = AwtColor(88, 207, 160, 235),
+        connectorArrow = AwtColor(45, 184, 128, 215)
+    )
+
+    val BLUE = palette(
+        id = "blue",
+        displayName = "Blue",
+        darkest = Color(0xFF071B3A),
+        dark = Color(0xFF1E3A8A),
+        mid = Color(0xFF3B82F6),
+        accent = Color(0xFF93C5FD),
+        alternate = Color(0xFF06B6D4),
+        glow = Color(0xFF7DD3FC),
+        meta = Color(0xFFDBEAFE),
+        connectorStroke = AwtColor(96, 165, 250, 235),
+        connectorArrow = AwtColor(59, 130, 246, 215)
+    )
+
+    val RED = palette(
+        id = "red",
+        displayName = "Red",
+        darkest = Color(0xFF33070A),
+        dark = Color(0xFF7F1D1D),
+        mid = Color(0xFFEF4444),
+        accent = Color(0xFFFCA5A5),
+        alternate = Color(0xFFF97316),
+        glow = Color(0xFFFCA5A5),
+        meta = Color(0xFFFEE2E2),
+        connectorStroke = AwtColor(248, 113, 113, 235),
+        connectorArrow = AwtColor(239, 68, 68, 215)
+    )
+
+    val ORANGE = palette(
+        id = "orange",
+        displayName = "Orange",
+        darkest = Color(0xFF2B1203),
+        dark = Color(0xFF7C2D12),
+        mid = Color(0xFFF97316),
+        accent = Color(0xFFFDBA74),
+        alternate = Color(0xFFEAB308),
+        glow = Color(0xFFFCD34D),
+        meta = Color(0xFFFFEDD5),
+        connectorStroke = AwtColor(251, 146, 60, 235),
+        connectorArrow = AwtColor(249, 115, 22, 215)
+    )
+
+    val TEAL = palette(
+        id = "teal",
+        displayName = "Teal",
+        darkest = Color(0xFF032F35),
+        dark = Color(0xFF155E75),
+        mid = Color(0xFF06B6D4),
+        accent = Color(0xFF67E8F9),
+        alternate = Color(0xFF22D3EE),
+        glow = Color(0xFF67E8F9),
+        meta = Color(0xFFCFFAFE),
+        connectorStroke = AwtColor(34, 211, 238, 235),
+        connectorArrow = AwtColor(6, 182, 212, 215)
+    )
+
+    val PINK = palette(
+        id = "pink",
+        displayName = "Pink",
+        darkest = Color(0xFF351024),
+        dark = Color(0xFF831843),
+        mid = Color(0xFFEC4899),
+        accent = Color(0xFFF9A8D4),
+        alternate = Color(0xFFA855F7),
+        glow = Color(0xFFF0ABFC),
+        meta = Color(0xFFFCE7F3),
+        connectorStroke = AwtColor(244, 114, 182, 235),
+        connectorArrow = AwtColor(236, 72, 153, 215)
+    )
+
+    val all: List<WalkthroughPalette> = listOf(PURPLE, GREEN, BLUE, RED, ORANGE, TEAL, PINK)
+    val default: WalkthroughPalette = PURPLE
+
+    private val byId = all.associateBy(WalkthroughPalette::id)
+
+    fun byId(id: String?): WalkthroughPalette = byId[id] ?: default
+
+    private fun palette(
+        id: String,
+        displayName: String,
+        darkest: Color,
+        dark: Color,
+        mid: Color,
+        accent: Color,
+        alternate: Color,
+        glow: Color,
+        meta: Color,
+        connectorStroke: AwtColor,
+        connectorArrow: AwtColor
+    ): WalkthroughPalette =
+        WalkthroughPalette(
+            id = id,
+            displayName = displayName,
+            backgroundGradientColors = listOf(darkest, dark, mid, alternate),
+            glowGradientColors = listOf(glow.copy(alpha = 0.4f), glow.copy(alpha = 0.33f), Color.Transparent),
+            overlayColor = WalkthroughColors.overlay,
+            borderGradientColors = listOf(mid, accent, alternate, mid),
+            scrollbarUnhoverColor = mid.copy(alpha = 0.4f),
+            scrollbarHoverColor = accent,
+            metaTextColor = meta,
+            badgeGradientColors = listOf(mid, accent, alternate),
+            navPrimaryGradientColors = listOf(mid, accent, dark),
+            navPrimaryBorderColor = accent,
+            connectorStrokeColor = connectorStroke,
+            connectorArrowFillColor = connectorArrow
+        )
+}

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupContent.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupContent.kt
@@ -51,8 +51,6 @@ private object WalkthroughPopupContentStyle {
     val scrollbarMinHeight = 28.dp
     val scrollbarThickness = 6.dp
     const val SCROLLBAR_HOVER_DURATION_MS = 300
-    val scrollbarUnhoverColor = WalkthroughColors.scrollbarIndigo
-    val scrollbarHoverColor = WalkthroughColors.pink
     const val ANIMATION_START = 0f
     const val ANIMATION_END = 1f
     const val GRADIENT_ANIMATION_DURATION_MS = 5400
@@ -62,32 +60,14 @@ private object WalkthroughPopupContentStyle {
     // SkiaLayer (and the editor underneath the translucent popup corners) only repaints at
     // this cadence. Lower values save more CPU at the cost of visible stepping.
     const val ANIMATION_FRAME_INTERVAL_MS = 67L
-    val backgroundGradientColors = listOf(
-        WalkthroughColors.veryDarkPurple,
-        WalkthroughColors.darkPurple,
-        WalkthroughColors.magenta,
-        WalkthroughColors.navyBlue
-    )
     const val BACKGROUND_START_X_SHIFT = 0.7f
     const val BACKGROUND_START_Y_SHIFT = 0.2f
     const val BACKGROUND_END_X_SHIFT = 0.5f
     const val BACKGROUND_END_Y_SHIFT = 1.1f
-    val glowGradientColors = listOf(
-        WalkthroughColors.lightPink.copy(alpha = 0.4f),
-        WalkthroughColors.glowLavender,
-        Color.Transparent
-    )
     const val GLOW_CENTER_BASE_X = 0.18f
     const val GLOW_CENTER_SHIFT_X = 0.62f
     const val GLOW_CENTER_Y = 0.2f
     const val GLOW_RADIUS_FACTOR = 0.95f
-    val overlayColor = WalkthroughColors.overlay
-    val borderGradientColors = listOf(
-        WalkthroughColors.purple,
-        WalkthroughColors.pink,
-        WalkthroughColors.blue,
-        WalkthroughColors.purple
-    )
     const val BORDER_GRADIENT_START_SHIFT = 1f
     const val BORDER_ALPHA = 0.9f
     val borderStrokeWidth = 1.5.dp
@@ -104,7 +84,6 @@ private object WalkthroughPopupContentStyle {
     const val HEADER_BORDER_ALPHA = 0.08f
     val headerPaddingHorizontal = 8.dp
     val headerPaddingVertical = 6.dp
-    val metaTextColor = WalkthroughColors.textMeta
     val metaTextSize = 12.sp
     val bodyCornerRadius = 18.dp
     const val BODY_BACKGROUND_ALPHA = 0.08f
@@ -128,6 +107,7 @@ private data class WalkthroughPopupAnimationState(
 internal fun WalkthroughItemContent(
     project: Project,
     items: List<WalkthroughItem>,
+    palette: WalkthroughPalette,
     onItemDisplayed: (WalkthroughItem) -> Unit,
     onNavigateToSource: (WalkthroughItem) -> Unit,
     onClose: () -> Unit
@@ -136,7 +116,7 @@ internal fun WalkthroughItemContent(
     val item = items[currentIndex]
     val scrollState = rememberScrollState()
     val animationState = rememberPopupAnimationState()
-    val scrollbarStyle = rememberPopupScrollbarStyle()
+    val scrollbarStyle = rememberPopupScrollbarStyle(palette)
     val showScrollbar = scrollState.maxValue > 0
 
     LaunchedEffect(item) {
@@ -150,6 +130,7 @@ internal fun WalkthroughItemContent(
             item = item,
             items = items,
             currentIndex = currentIndex,
+            palette = palette,
             scrollState = scrollState,
             showScrollbar = showScrollbar,
             animationState = animationState,
@@ -186,15 +167,15 @@ private fun rememberPopupAnimationState(): WalkthroughPopupAnimationState {
 }
 
 @Composable
-private fun rememberPopupScrollbarStyle(): ScrollbarStyle =
-    remember {
+private fun rememberPopupScrollbarStyle(palette: WalkthroughPalette): ScrollbarStyle =
+    remember(palette) {
         ScrollbarStyle(
             minimalHeight = WalkthroughPopupContentStyle.scrollbarMinHeight,
             thickness = WalkthroughPopupContentStyle.scrollbarThickness,
             shape = CircleShape,
             hoverDurationMillis = WalkthroughPopupContentStyle.SCROLLBAR_HOVER_DURATION_MS,
-            unhoverColor = WalkthroughPopupContentStyle.scrollbarUnhoverColor,
-            hoverColor = WalkthroughPopupContentStyle.scrollbarHoverColor
+            unhoverColor = palette.scrollbarUnhoverColor,
+            hoverColor = palette.scrollbarHoverColor
         )
     }
 
@@ -204,6 +185,7 @@ private fun WalkthroughPopupFrame(
     item: WalkthroughItem,
     items: List<WalkthroughItem>,
     currentIndex: Int,
+    palette: WalkthroughPalette,
     scrollState: ScrollState,
     showScrollbar: Boolean,
     animationState: WalkthroughPopupAnimationState,
@@ -217,7 +199,7 @@ private fun WalkthroughPopupFrame(
         modifier = Modifier
             .fillMaxSize()
             .clip(shape)
-            .walkthroughPopupBackground(animationState)
+            .walkthroughPopupBackground(animationState, palette)
     ) {
         AiCloseButton(
             modifier = Modifier
@@ -246,7 +228,7 @@ private fun WalkthroughPopupFrame(
                 ),
             verticalArrangement = Arrangement.spacedBy(WalkthroughPopupContentStyle.contentSectionSpacing)
         ) {
-            WalkthroughPopupHeader(item = item, items = items, currentIndex = currentIndex)
+            WalkthroughPopupHeader(item = item, items = items, currentIndex = currentIndex, palette = palette)
             WalkthroughPopupBody(
                 project = project,
                 item = item,
@@ -257,6 +239,7 @@ private fun WalkthroughPopupFrame(
                 WalkthroughPopupNavigation(
                     currentIndex = currentIndex,
                     lastIndex = items.lastIndex,
+                    palette = palette,
                     onPrevious = onPrevious,
                     onNext = onNext
                 )
@@ -266,14 +249,15 @@ private fun WalkthroughPopupFrame(
 }
 
 private fun Modifier.walkthroughPopupBackground(
-    animationState: WalkthroughPopupAnimationState
+    animationState: WalkthroughPopupAnimationState,
+    palette: WalkthroughPalette
 ): Modifier = drawWithCache {
     val cornerRadius = CornerRadius(
         WalkthroughPopupContentStyle.cornerRadius.toPx(),
         WalkthroughPopupContentStyle.cornerRadius.toPx()
     )
     val backgroundBrush = Brush.linearGradient(
-        colors = WalkthroughPopupContentStyle.backgroundGradientColors,
+        colors = palette.backgroundGradientColors,
         start = Offset(
             size.width * (animationState.gradientShift - WalkthroughPopupContentStyle.BACKGROUND_START_X_SHIFT),
             -size.height * WalkthroughPopupContentStyle.BACKGROUND_START_Y_SHIFT
@@ -284,7 +268,7 @@ private fun Modifier.walkthroughPopupBackground(
         )
     )
     val glowBrush = Brush.radialGradient(
-        colors = WalkthroughPopupContentStyle.glowGradientColors,
+        colors = palette.glowGradientColors,
         center = Offset(
             size.width * (
                 WalkthroughPopupContentStyle.GLOW_CENTER_BASE_X +
@@ -295,7 +279,7 @@ private fun Modifier.walkthroughPopupBackground(
         radius = size.minDimension * WalkthroughPopupContentStyle.GLOW_RADIUS_FACTOR
     )
     val borderBrush = Brush.linearGradient(
-        colors = WalkthroughPopupContentStyle.borderGradientColors,
+        colors = palette.borderGradientColors,
         start = Offset(
             size.width * (animationState.gradientShift - WalkthroughPopupContentStyle.BORDER_GRADIENT_START_SHIFT),
             0f
@@ -306,7 +290,7 @@ private fun Modifier.walkthroughPopupBackground(
     onDrawBehind {
         drawRoundRect(brush = backgroundBrush, cornerRadius = cornerRadius)
         drawRoundRect(brush = glowBrush, cornerRadius = cornerRadius)
-        drawRoundRect(color = WalkthroughPopupContentStyle.overlayColor, cornerRadius = cornerRadius)
+        drawRoundRect(color = palette.overlayColor, cornerRadius = cornerRadius)
         drawRoundRect(
             brush = borderBrush,
             cornerRadius = cornerRadius,
@@ -320,7 +304,8 @@ private fun Modifier.walkthroughPopupBackground(
 private fun WalkthroughPopupHeader(
     item: WalkthroughItem,
     items: List<WalkthroughItem>,
-    currentIndex: Int
+    currentIndex: Int,
+    palette: WalkthroughPalette
 ) {
     Row(
         horizontalArrangement = Arrangement.spacedBy(WalkthroughPopupContentStyle.headerSpacing),
@@ -339,18 +324,18 @@ private fun WalkthroughPopupHeader(
                 vertical = WalkthroughPopupContentStyle.headerPaddingVertical
             )
     ) {
-        AiBadge()
+        AiBadge(palette)
         if (items.size > 1) {
             Text(
                 text = "${currentIndex + 1} / ${items.size}",
-                color = WalkthroughPopupContentStyle.metaTextColor,
+                color = palette.metaTextColor,
                 fontSize = WalkthroughPopupContentStyle.metaTextSize,
                 fontWeight = FontWeight.Medium
             )
         } else if (item.line != null) {
             Text(
                 text = "Line ${item.line}",
-                color = WalkthroughPopupContentStyle.metaTextColor,
+                color = palette.metaTextColor,
                 fontSize = WalkthroughPopupContentStyle.metaTextSize,
                 fontWeight = FontWeight.Medium
             )

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupSurface.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupSurface.kt
@@ -5,7 +5,6 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.event.VisibleAreaEvent
 import com.intellij.openapi.editor.event.VisibleAreaListener
 import java.awt.BasicStroke
-import java.awt.Color as AwtColor
 import java.awt.Dimension
 import java.awt.Graphics
 import java.awt.Graphics2D
@@ -42,12 +41,6 @@ internal object WalkthroughConnectorStyle {
     const val ARROW_SPREAD_DEGREES = 24.0
     const val ARROW_HEAD_LENGTH = 13.0
     const val STROKE_WIDTH = 3.5f
-
-    @Suppress("UseJBColor")
-    val strokeColor = AwtColor(255, 136, 136, 235)
-
-    @Suppress("UseJBColor")
-    val arrowFillColor = AwtColor(255, 102, 102, 215)
 }
 
 private data class ConnectorPaintContext(
@@ -58,6 +51,7 @@ private data class ConnectorPaintContext(
 
 internal class WalkthroughPopupSurface(
     val content: JComponent,
+    private val palette: WalkthroughPalette,
     private val onCloseRequested: () -> Unit
 ) : JComponent(), VisibleAreaListener, Disposable {
     private var editor: Editor? = null
@@ -147,14 +141,14 @@ internal class WalkthroughPopupSurface(
                 RenderingHints.KEY_ANTIALIASING,
                 RenderingHints.VALUE_ANTIALIAS_ON
             )
-            graphics2D.color = WalkthroughConnectorStyle.strokeColor
+            graphics2D.color = palette.connectorStrokeColor
             graphics2D.stroke = BasicStroke(
                 WalkthroughConnectorStyle.STROKE_WIDTH,
                 BasicStroke.CAP_ROUND,
                 BasicStroke.JOIN_ROUND
             )
             graphics2D.draw(connector.path)
-            drawArrowHead(graphics2D, connector.end, connector.endControl)
+            drawArrowHead(graphics2D, connector.end, connector.endControl, palette)
         } finally {
             graphics2D.dispose()
         }
@@ -336,7 +330,12 @@ private fun buildConnector(anchor: ConnectorAnchor, end: Point2D.Float): Connect
     return ConnectorPath(path, end, endControl)
 }
 
-private fun drawArrowHead(graphics: Graphics2D, end: Point2D.Float, endControl: Point2D.Float) {
+private fun drawArrowHead(
+    graphics: Graphics2D,
+    end: Point2D.Float,
+    endControl: Point2D.Float,
+    palette: WalkthroughPalette
+) {
     val angle = atan2((end.y - endControl.y).toDouble(), (end.x - endControl.x).toDouble())
     val spread = Math.toRadians(WalkthroughConnectorStyle.ARROW_SPREAD_DEGREES)
     val headLength = WalkthroughConnectorStyle.ARROW_HEAD_LENGTH
@@ -350,6 +349,6 @@ private fun drawArrowHead(graphics: Graphics2D, end: Point2D.Float, endControl: 
         lineTo(rightX.toDouble(), rightY.toDouble())
         closePath()
     }
-    graphics.color = WalkthroughConnectorStyle.arrowFillColor
+    graphics.color = palette.connectorArrowFillColor
     graphics.fill(arrow)
 }

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupSurface.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupSurface.kt
@@ -51,7 +51,7 @@ private data class ConnectorPaintContext(
 
 internal class WalkthroughPopupSurface(
     val content: JComponent,
-    private val palette: WalkthroughPalette,
+    private var palette: WalkthroughPalette,
     private val onCloseRequested: () -> Unit
 ) : JComponent(), VisibleAreaListener, Disposable {
     private var editor: Editor? = null
@@ -103,6 +103,11 @@ internal class WalkthroughPopupSurface(
             }
         }
         refreshBounds()
+        repaint()
+    }
+
+    fun updatePalette(palette: WalkthroughPalette) {
+        this.palette = palette
         repaint()
     }
 

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupWidgets.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupWidgets.kt
@@ -26,11 +26,6 @@ import org.jetbrains.jewel.ui.icons.AllIconsKeys
 
 private object WalkthroughWidgetStyle {
     val navigationSpacing = 10.dp
-    val badgeGradientColors = listOf(
-        WalkthroughColors.purple,
-        WalkthroughColors.pink,
-        WalkthroughColors.blue
-    )
     val badgePaddingHorizontal = 12.dp
     val badgePaddingVertical = 6.dp
     val badgeTextSize = 11.sp
@@ -39,16 +34,10 @@ private object WalkthroughWidgetStyle {
     val closeButtonBorderWidth = 1.dp
     const val CLOSE_BUTTON_BORDER_ALPHA = 0.18f
     val closeButtonTextSize = 13.sp
-    val navPrimaryGradientColors = listOf(
-        WalkthroughColors.purple,
-        WalkthroughColors.pink,
-        WalkthroughColors.deepPurple
-    )
     val navSecondaryGradientColors = listOf(
         Color.White.copy(alpha = 0.12f),
         Color.White.copy(alpha = 0.08f)
     )
-    val navPrimaryBorderColor = WalkthroughColors.lightPink
     const val NAV_TEXT_DISABLED_ALPHA = 0.45f
     val navHorizontalPadding = 14.dp
     val navVerticalPadding = 8.dp
@@ -59,6 +48,7 @@ private object WalkthroughWidgetStyle {
 internal fun WalkthroughPopupNavigation(
     currentIndex: Int,
     lastIndex: Int,
+    palette: WalkthroughPalette,
     onPrevious: () -> Unit,
     onNext: () -> Unit
 ) {
@@ -71,23 +61,25 @@ internal fun WalkthroughPopupNavigation(
             label = "Previous",
             enabled = currentIndex > 0,
             emphasized = false,
+            palette = palette,
             onClick = onPrevious
         )
         AiNavButton(
             label = "Next",
             enabled = currentIndex < lastIndex,
             emphasized = true,
+            palette = palette,
             onClick = onNext
         )
     }
 }
 
 @Composable
-internal fun AiBadge() {
+internal fun AiBadge(palette: WalkthroughPalette) {
     Box(
         modifier = Modifier
             .clip(CircleShape)
-            .background(brush = Brush.linearGradient(WalkthroughWidgetStyle.badgeGradientColors))
+            .background(brush = Brush.linearGradient(palette.badgeGradientColors))
             .padding(
                 horizontal = WalkthroughWidgetStyle.badgePaddingHorizontal,
                 vertical = WalkthroughWidgetStyle.badgePaddingVertical
@@ -154,15 +146,16 @@ internal fun AiNavButton(
     label: String,
     enabled: Boolean,
     emphasized: Boolean,
+    palette: WalkthroughPalette,
     onClick: () -> Unit
 ) {
     val backgroundBrush = if (emphasized) {
-        Brush.linearGradient(WalkthroughWidgetStyle.navPrimaryGradientColors)
+        Brush.linearGradient(palette.navPrimaryGradientColors)
     } else {
         Brush.linearGradient(WalkthroughWidgetStyle.navSecondaryGradientColors)
     }
     val borderColor = if (emphasized) {
-        WalkthroughWidgetStyle.navPrimaryBorderColor
+        palette.navPrimaryBorderColor
     } else {
         Color.White.copy(alpha = WalkthroughWidgetStyle.CLOSE_BUTTON_BORDER_ALPHA)
     }

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughSettings.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughSettings.kt
@@ -1,0 +1,39 @@
+package com.forketyfork.walkthrough
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+
+@State(
+    name = "WalkthroughSettings",
+    storages = [Storage("walkthrough.xml")]
+)
+internal class WalkthroughSettings : PersistentStateComponent<WalkthroughSettings.State> {
+    private var state = State()
+
+    var selectedPaletteId: String
+        get() = state.selectedPaletteId
+        set(value) {
+            state.selectedPaletteId = WalkthroughPalettes.byId(value).id
+        }
+
+    val selectedPalette: WalkthroughPalette
+        get() = WalkthroughPalettes.byId(selectedPaletteId)
+
+    override fun getState(): State = state
+
+    override fun loadState(state: State) {
+        this.state = state
+        selectedPaletteId = state.selectedPaletteId
+    }
+
+    class State {
+        var selectedPaletteId: String = WalkthroughPalettes.default.id
+    }
+
+    companion object {
+        fun getInstance(): WalkthroughSettings =
+            ApplicationManager.getApplication().getService(WalkthroughSettings::class.java)
+    }
+}

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughSettings.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughSettings.kt
@@ -15,7 +15,12 @@ internal class WalkthroughSettings : PersistentStateComponent<WalkthroughSetting
     var selectedPaletteId: String
         get() = state.selectedPaletteId
         set(value) {
-            state.selectedPaletteId = WalkthroughPalettes.byId(value).id
+            val palette = WalkthroughPalettes.byId(value)
+            if (state.selectedPaletteId == palette.id) {
+                return
+            }
+            state.selectedPaletteId = palette.id
+            notifyPaletteChanged(palette)
         }
 
     val selectedPalette: WalkthroughPalette
@@ -25,11 +30,18 @@ internal class WalkthroughSettings : PersistentStateComponent<WalkthroughSetting
 
     override fun loadState(state: State) {
         this.state = state
-        selectedPaletteId = state.selectedPaletteId
+        this.state.selectedPaletteId = WalkthroughPalettes.byId(state.selectedPaletteId).id
     }
 
     class State {
         var selectedPaletteId: String = WalkthroughPalettes.default.id
+    }
+
+    private fun notifyPaletteChanged(palette: WalkthroughPalette) {
+        ApplicationManager.getApplication()
+            .messageBus
+            .syncPublisher(WalkthroughSettingsListener.TOPIC)
+            .paletteChanged(palette)
     }
 
     companion object {

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughSettings.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughSettings.kt
@@ -6,8 +6,8 @@ import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
 
 @State(
-    name = "WalkthroughSettings",
-    storages = [Storage("walkthrough.xml")]
+    name = "com.forketyfork.walkthrough.WalkthroughSettings",
+    storages = [Storage("com.forketyfork.walkthrough.settings.xml")]
 )
 internal class WalkthroughSettings : PersistentStateComponent<WalkthroughSettings.State> {
     private var state = State()

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughSettingsConfigurable.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughSettingsConfigurable.kt
@@ -1,0 +1,157 @@
+package com.forketyfork.walkthrough
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.intellij.openapi.options.Configurable
+import javax.swing.JComponent
+import org.jetbrains.jewel.bridge.JewelComposePanel
+import org.jetbrains.jewel.ui.component.Text
+
+private object WalkthroughSettingsStyle {
+    val contentPadding = 16.dp
+    val paletteSpacing = 10.dp
+    val rowSpacing = 12.dp
+    val rowCornerRadius = 8.dp
+    val rowPaddingHorizontal = 10.dp
+    val rowPaddingVertical = 8.dp
+    val swatchSize = 92.dp
+    val swatchHeight = 24.dp
+    val swatchCornerRadius = 6.dp
+    val swatchBorderWidth = 1.dp
+    val selectedBorderWidth = 2.dp
+    val unselectedBorderWidth = 1.dp
+    val titleTextSize = 13.sp
+    val unselectedBorderColor = Color.Gray.copy(alpha = 0.24f)
+    val rowBackgroundColor = Color.Gray.copy(alpha = 0.08f)
+    val swatchBorderColor = Color.Black.copy(alpha = 0.16f)
+}
+
+internal class WalkthroughSettingsConfigurable : Configurable {
+    private var selectedPaletteId by mutableStateOf(WalkthroughSettings.getInstance().selectedPaletteId)
+    private var component: JComponent? = null
+
+    override fun getDisplayName(): String = "Walkthrough"
+
+    override fun createComponent(): JComponent =
+        JewelComposePanel {
+            WalkthroughSettingsPanel(
+                selectedPaletteId = selectedPaletteId,
+                onPaletteSelected = { selectedPaletteId = it }
+            )
+        }.also {
+            component = it
+        }
+
+    override fun isModified(): Boolean =
+        selectedPaletteId != WalkthroughSettings.getInstance().selectedPaletteId
+
+    override fun apply() {
+        WalkthroughSettings.getInstance().selectedPaletteId = selectedPaletteId
+        selectedPaletteId = WalkthroughSettings.getInstance().selectedPaletteId
+    }
+
+    override fun reset() {
+        selectedPaletteId = WalkthroughSettings.getInstance().selectedPaletteId
+    }
+
+    override fun disposeUIResources() {
+        component = null
+    }
+}
+
+@Composable
+private fun WalkthroughSettingsPanel(
+    selectedPaletteId: String,
+    onPaletteSelected: (String) -> Unit
+) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(WalkthroughSettingsStyle.paletteSpacing),
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(WalkthroughSettingsStyle.contentPadding)
+    ) {
+        WalkthroughPalettes.all.forEach { palette ->
+            WalkthroughPaletteOption(
+                palette = palette,
+                selected = palette.id == selectedPaletteId,
+                onSelected = { onPaletteSelected(palette.id) }
+            )
+        }
+    }
+}
+
+@Composable
+private fun WalkthroughPaletteOption(
+    palette: WalkthroughPalette,
+    selected: Boolean,
+    onSelected: () -> Unit
+) {
+    val borderWidth = if (selected) {
+        WalkthroughSettingsStyle.selectedBorderWidth
+    } else {
+        WalkthroughSettingsStyle.unselectedBorderWidth
+    }
+    val borderColor = if (selected) {
+        palette.navPrimaryBorderColor
+    } else {
+        WalkthroughSettingsStyle.unselectedBorderColor
+    }
+
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(WalkthroughSettingsStyle.rowSpacing),
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(WalkthroughSettingsStyle.rowCornerRadius))
+            .background(WalkthroughSettingsStyle.rowBackgroundColor)
+            .border(
+                width = borderWidth,
+                color = borderColor,
+                shape = RoundedCornerShape(WalkthroughSettingsStyle.rowCornerRadius)
+            )
+            .clickable(onClick = onSelected)
+            .padding(
+                horizontal = WalkthroughSettingsStyle.rowPaddingHorizontal,
+                vertical = WalkthroughSettingsStyle.rowPaddingVertical
+            )
+    ) {
+        Box(
+            modifier = Modifier
+                .size(WalkthroughSettingsStyle.swatchSize, WalkthroughSettingsStyle.swatchHeight)
+                .clip(RoundedCornerShape(WalkthroughSettingsStyle.swatchCornerRadius))
+                .background(Brush.linearGradient(palette.swatchGradientColors))
+                .border(
+                    width = WalkthroughSettingsStyle.swatchBorderWidth,
+                    color = WalkthroughSettingsStyle.swatchBorderColor,
+                    shape = RoundedCornerShape(WalkthroughSettingsStyle.swatchCornerRadius)
+                )
+        )
+        Text(
+            text = palette.displayName,
+            color = Color.Unspecified,
+            fontSize = WalkthroughSettingsStyle.titleTextSize,
+            fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Medium
+        )
+    }
+}

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughSettingsConfigurable.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughSettingsConfigurable.kt
@@ -49,7 +49,6 @@ private object WalkthroughSettingsStyle {
 
 internal class WalkthroughSettingsConfigurable : Configurable {
     private var selectedPaletteId by mutableStateOf(WalkthroughSettings.getInstance().selectedPaletteId)
-    private var component: JComponent? = null
 
     override fun getDisplayName(): String = "Walkthrough"
 
@@ -59,8 +58,6 @@ internal class WalkthroughSettingsConfigurable : Configurable {
                 selectedPaletteId = selectedPaletteId,
                 onPaletteSelected = { selectedPaletteId = it }
             )
-        }.also {
-            component = it
         }
 
     override fun isModified(): Boolean =
@@ -73,10 +70,6 @@ internal class WalkthroughSettingsConfigurable : Configurable {
 
     override fun reset() {
         selectedPaletteId = WalkthroughSettings.getInstance().selectedPaletteId
-    }
-
-    override fun disposeUIResources() {
-        component = null
     }
 }
 

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughSettingsConfigurable.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughSettingsConfigurable.kt
@@ -1,64 +1,84 @@
 package com.forketyfork.walkthrough
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
+import androidx.compose.ui.graphics.toArgb
 import com.intellij.openapi.options.Configurable
+import com.intellij.ui.JBColor
+import com.intellij.util.ui.JBUI
+import java.awt.Color as AwtColor
+import java.awt.Component
+import java.awt.Dimension
+import java.awt.Graphics
+import java.awt.Graphics2D
+import java.awt.GridBagConstraints
+import java.awt.GridBagLayout
+import java.awt.Insets
+import java.awt.LinearGradientPaint
+import java.awt.Paint
+import java.awt.RenderingHints
+import java.awt.event.MouseAdapter
+import java.awt.event.MouseEvent
+import java.awt.geom.RoundRectangle2D
+import javax.swing.ButtonGroup
 import javax.swing.JComponent
-import org.jetbrains.jewel.bridge.JewelComposePanel
-import org.jetbrains.jewel.ui.component.Text
+import javax.swing.JPanel
+import javax.swing.JRadioButton
 
 private object WalkthroughSettingsStyle {
-    val contentPadding = 16.dp
-    val paletteSpacing = 10.dp
-    val rowSpacing = 12.dp
-    val rowCornerRadius = 8.dp
-    val rowPaddingHorizontal = 10.dp
-    val rowPaddingVertical = 8.dp
-    val swatchSize = 92.dp
-    val swatchHeight = 24.dp
-    val swatchCornerRadius = 6.dp
-    val swatchBorderWidth = 1.dp
-    val selectedBorderWidth = 2.dp
-    val unselectedBorderWidth = 1.dp
-    val titleTextSize = 13.sp
-    val unselectedBorderColor = Color.Gray.copy(alpha = 0.24f)
-    val rowBackgroundColor = Color.Gray.copy(alpha = 0.08f)
-    val swatchBorderColor = Color.Black.copy(alpha = 0.16f)
+    const val SWATCH_WIDTH = 92
+    const val SWATCH_HEIGHT = 24
+    const val SWATCH_ARC = 8
+    const val PANEL_PADDING = 16
+    const val ROW_GAP = 10
+    const val COLUMN_GAP = 12
+    const val RGB_MIN = 0
+    const val RGB_MAX = 255
+    const val SWATCH_BORDER_ALPHA = 48
+    const val MIN_PAINT_SIZE = 1
+    const val MIN_GRADIENT_COLOR_COUNT = 2
 }
 
 internal class WalkthroughSettingsConfigurable : Configurable {
-    private var selectedPaletteId by mutableStateOf(WalkthroughSettings.getInstance().selectedPaletteId)
+    private var selectedPaletteId = WalkthroughSettings.getInstance().selectedPaletteId
+    private var paletteButtons = emptyMap<String, JRadioButton>()
 
     override fun getDisplayName(): String = "Walkthrough"
 
-    override fun createComponent(): JComponent =
-        JewelComposePanel {
-            WalkthroughSettingsPanel(
-                selectedPaletteId = selectedPaletteId,
-                onPaletteSelected = { selectedPaletteId = it }
-            )
+    override fun createComponent(): JComponent {
+        val buttonGroup = ButtonGroup()
+        val buttons = mutableMapOf<String, JRadioButton>()
+        val panel = JPanel(GridBagLayout()).apply {
+            border = JBUI.Borders.empty(WalkthroughSettingsStyle.PANEL_PADDING)
+            background = JBColor.PanelBackground
         }
+
+        WalkthroughPalettes.all.forEachIndexed { index, palette ->
+            val selectOnPress = object : MouseAdapter() {
+                override fun mousePressed(event: MouseEvent) {
+                    selectPalette(palette.id)
+                }
+            }
+            val radioButton = JRadioButton(palette.displayName).apply {
+                isSelected = palette.id == selectedPaletteId
+                isOpaque = false
+                addActionListener { selectPalette(palette.id) }
+            }
+            val swatch = PaletteSwatch(palette).apply {
+                alignmentX = Component.LEFT_ALIGNMENT
+                addMouseListener(selectOnPress)
+            }
+            val row = PaletteRow(radioButton, swatch).apply {
+                addMouseListener(selectOnPress)
+            }
+
+            buttonGroup.add(radioButton)
+            buttons[palette.id] = radioButton
+            panel.add(row, rowConstraints(index))
+        }
+
+        panel.add(JPanel().apply { isOpaque = false }, fillerConstraints())
+        paletteButtons = buttons
+        return panel
+    }
 
     override fun isModified(): Boolean =
         selectedPaletteId != WalkthroughSettings.getInstance().selectedPaletteId
@@ -66,85 +86,140 @@ internal class WalkthroughSettingsConfigurable : Configurable {
     override fun apply() {
         WalkthroughSettings.getInstance().selectedPaletteId = selectedPaletteId
         selectedPaletteId = WalkthroughSettings.getInstance().selectedPaletteId
+        updateSelection()
     }
 
     override fun reset() {
         selectedPaletteId = WalkthroughSettings.getInstance().selectedPaletteId
+        updateSelection()
     }
+
+    private fun selectPalette(paletteId: String) {
+        selectedPaletteId = paletteId
+        updateSelection()
+    }
+
+    private fun updateSelection() {
+        paletteButtons[selectedPaletteId]?.isSelected = true
+    }
+
+    private fun rowConstraints(index: Int): GridBagConstraints =
+        GridBagConstraints().apply {
+            gridx = 0
+            gridy = index
+            weightx = 1.0
+            fill = GridBagConstraints.HORIZONTAL
+            anchor = GridBagConstraints.NORTHWEST
+            insets = Insets(0, 0, WalkthroughSettingsStyle.ROW_GAP, 0)
+        }
+
+    private fun fillerConstraints(): GridBagConstraints =
+        GridBagConstraints().apply {
+            gridx = 0
+            gridy = WalkthroughPalettes.all.size
+            weightx = 1.0
+            weighty = 1.0
+            fill = GridBagConstraints.BOTH
+        }
 }
 
-@Composable
-private fun WalkthroughSettingsPanel(
-    selectedPaletteId: String,
-    onPaletteSelected: (String) -> Unit
-) {
-    Column(
-        verticalArrangement = Arrangement.spacedBy(WalkthroughSettingsStyle.paletteSpacing),
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(WalkthroughSettingsStyle.contentPadding)
-    ) {
-        WalkthroughPalettes.all.forEach { palette ->
-            WalkthroughPaletteOption(
-                palette = palette,
-                selected = palette.id == selectedPaletteId,
-                onSelected = { onPaletteSelected(palette.id) }
+private class PaletteRow(
+    radioButton: JRadioButton,
+    swatch: JComponent
+) : JPanel(GridBagLayout()) {
+    init {
+        isOpaque = false
+        cursor = radioButton.cursor
+        add(swatch, swatchConstraints())
+        add(radioButton, labelConstraints())
+    }
+
+    private fun swatchConstraints(): GridBagConstraints =
+        GridBagConstraints().apply {
+            gridx = 0
+            gridy = 0
+            anchor = GridBagConstraints.WEST
+            insets = Insets(0, 0, 0, WalkthroughSettingsStyle.COLUMN_GAP)
+        }
+
+    private fun labelConstraints(): GridBagConstraints =
+        GridBagConstraints().apply {
+            gridx = 1
+            gridy = 0
+            weightx = 1.0
+            fill = GridBagConstraints.HORIZONTAL
+            anchor = GridBagConstraints.WEST
+        }
+}
+
+private class PaletteSwatch(
+    private val palette: WalkthroughPalette
+) : JComponent() {
+    init {
+        preferredSize = Dimension(WalkthroughSettingsStyle.SWATCH_WIDTH, WalkthroughSettingsStyle.SWATCH_HEIGHT)
+        minimumSize = preferredSize
+        maximumSize = preferredSize
+        toolTipText = palette.displayName
+        accessibleContext?.accessibleName = "${palette.displayName} palette"
+    }
+
+    override fun paintComponent(graphics: Graphics) {
+        super.paintComponent(graphics)
+        val graphics2d = graphics.create() as Graphics2D
+        try {
+            graphics2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
+            val shape = RoundRectangle2D.Float(
+                0f,
+                0f,
+                width.toFloat(),
+                height.toFloat(),
+                WalkthroughSettingsStyle.SWATCH_ARC.toFloat(),
+                WalkthroughSettingsStyle.SWATCH_ARC.toFloat()
             )
+
+            graphics2d.paint = swatchPaint()
+            graphics2d.fill(shape)
+            graphics2d.color = JBColor(
+                AwtColor(
+                    WalkthroughSettingsStyle.RGB_MIN,
+                    WalkthroughSettingsStyle.RGB_MIN,
+                    WalkthroughSettingsStyle.RGB_MIN,
+                    WalkthroughSettingsStyle.SWATCH_BORDER_ALPHA
+                ),
+                AwtColor(
+                    WalkthroughSettingsStyle.RGB_MAX,
+                    WalkthroughSettingsStyle.RGB_MAX,
+                    WalkthroughSettingsStyle.RGB_MAX,
+                    WalkthroughSettingsStyle.SWATCH_BORDER_ALPHA
+                )
+            )
+            graphics2d.draw(shape)
+        } finally {
+            graphics2d.dispose()
         }
     }
-}
 
-@Composable
-private fun WalkthroughPaletteOption(
-    palette: WalkthroughPalette,
-    selected: Boolean,
-    onSelected: () -> Unit
-) {
-    val borderWidth = if (selected) {
-        WalkthroughSettingsStyle.selectedBorderWidth
-    } else {
-        WalkthroughSettingsStyle.unselectedBorderWidth
-    }
-    val borderColor = if (selected) {
-        palette.navPrimaryBorderColor
-    } else {
-        WalkthroughSettingsStyle.unselectedBorderColor
-    }
+    private fun swatchPaint(): Paint {
+        val colors = palette.swatchGradientColors.map { AwtColor(it.toArgb(), true) }
+        if (
+            colors.size < WalkthroughSettingsStyle.MIN_GRADIENT_COLOR_COUNT ||
+            width < WalkthroughSettingsStyle.MIN_PAINT_SIZE ||
+            height < WalkthroughSettingsStyle.MIN_PAINT_SIZE
+        ) {
+            return colors.firstOrNull() ?: JBColor.GRAY
+        }
 
-    Row(
-        horizontalArrangement = Arrangement.spacedBy(WalkthroughSettingsStyle.rowSpacing),
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier
-            .fillMaxWidth()
-            .clip(RoundedCornerShape(WalkthroughSettingsStyle.rowCornerRadius))
-            .background(WalkthroughSettingsStyle.rowBackgroundColor)
-            .border(
-                width = borderWidth,
-                color = borderColor,
-                shape = RoundedCornerShape(WalkthroughSettingsStyle.rowCornerRadius)
-            )
-            .clickable(onClick = onSelected)
-            .padding(
-                horizontal = WalkthroughSettingsStyle.rowPaddingHorizontal,
-                vertical = WalkthroughSettingsStyle.rowPaddingVertical
-            )
-    ) {
-        Box(
-            modifier = Modifier
-                .size(WalkthroughSettingsStyle.swatchSize, WalkthroughSettingsStyle.swatchHeight)
-                .clip(RoundedCornerShape(WalkthroughSettingsStyle.swatchCornerRadius))
-                .background(Brush.linearGradient(palette.swatchGradientColors))
-                .border(
-                    width = WalkthroughSettingsStyle.swatchBorderWidth,
-                    color = WalkthroughSettingsStyle.swatchBorderColor,
-                    shape = RoundedCornerShape(WalkthroughSettingsStyle.swatchCornerRadius)
-                )
-        )
-        Text(
-            text = palette.displayName,
-            color = Color.Unspecified,
-            fontSize = WalkthroughSettingsStyle.titleTextSize,
-            fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Medium
+        val fractions = FloatArray(colors.size) { index ->
+            index.toFloat() / colors.lastIndex.toFloat()
+        }
+
+        return LinearGradientPaint(
+            0f,
+            0f,
+            width.toFloat(),
+            height.toFloat(),
+            fractions,
+            colors.toTypedArray()
         )
     }
 }

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughSettingsConfigurable.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughSettingsConfigurable.kt
@@ -7,6 +7,7 @@ import com.intellij.util.ui.JBUI
 import java.awt.Color as AwtColor
 import java.awt.Component
 import java.awt.Dimension
+import java.awt.Font
 import java.awt.Graphics
 import java.awt.Graphics2D
 import java.awt.GridBagConstraints
@@ -20,10 +21,13 @@ import java.awt.event.MouseEvent
 import java.awt.geom.RoundRectangle2D
 import javax.swing.ButtonGroup
 import javax.swing.JComponent
+import javax.swing.JLabel
 import javax.swing.JPanel
 import javax.swing.JRadioButton
 
 private object WalkthroughSettingsStyle {
+    const val HEADING_BOTTOM_GAP = 4
+    const val DESCRIPTION_BOTTOM_GAP = 14
     const val SWATCH_WIDTH = 92
     const val SWATCH_HEIGHT = 24
     const val SWATCH_ARC = 8
@@ -50,8 +54,18 @@ internal class WalkthroughSettingsConfigurable : Configurable {
             border = JBUI.Borders.empty(WalkthroughSettingsStyle.PANEL_PADDING)
             background = JBColor.PanelBackground
         }
+        var gridRow = 0
 
-        WalkthroughPalettes.all.forEachIndexed { index, palette ->
+        panel.add(
+            settingsHeading(),
+            fullWidthConstraints(gridRow++, WalkthroughSettingsStyle.HEADING_BOTTOM_GAP)
+        )
+        panel.add(
+            settingsDescription(),
+            fullWidthConstraints(gridRow++, WalkthroughSettingsStyle.DESCRIPTION_BOTTOM_GAP)
+        )
+
+        WalkthroughPalettes.all.forEach { palette ->
             val selectOnPress = object : MouseAdapter() {
                 override fun mousePressed(event: MouseEvent) {
                     selectPalette(palette.id)
@@ -72,10 +86,10 @@ internal class WalkthroughSettingsConfigurable : Configurable {
 
             buttonGroup.add(radioButton)
             buttons[palette.id] = radioButton
-            panel.add(row, rowConstraints(index))
+            panel.add(row, rowConstraints(gridRow++))
         }
 
-        panel.add(JPanel().apply { isOpaque = false }, fillerConstraints())
+        panel.add(JPanel().apply { isOpaque = false }, fillerConstraints(gridRow))
         paletteButtons = buttons
         return panel
     }
@@ -102,26 +116,46 @@ internal class WalkthroughSettingsConfigurable : Configurable {
     private fun updateSelection() {
         paletteButtons[selectedPaletteId]?.isSelected = true
     }
-
-    private fun rowConstraints(index: Int): GridBagConstraints =
-        GridBagConstraints().apply {
-            gridx = 0
-            gridy = index
-            weightx = 1.0
-            fill = GridBagConstraints.HORIZONTAL
-            anchor = GridBagConstraints.NORTHWEST
-            insets = Insets(0, 0, WalkthroughSettingsStyle.ROW_GAP, 0)
-        }
-
-    private fun fillerConstraints(): GridBagConstraints =
-        GridBagConstraints().apply {
-            gridx = 0
-            gridy = WalkthroughPalettes.all.size
-            weightx = 1.0
-            weighty = 1.0
-            fill = GridBagConstraints.BOTH
-        }
 }
+
+private fun settingsHeading(): JLabel =
+    JLabel("Walkthrough popup colors").apply {
+        font = font.deriveFont(Font.BOLD)
+    }
+
+private fun settingsDescription(): JLabel =
+    JLabel("These palettes style the popup background, border, controls, scrollbar, and source connector.").apply {
+        foreground = JBColor.GRAY
+    }
+
+private fun fullWidthConstraints(gridRow: Int, bottomInset: Int): GridBagConstraints =
+    GridBagConstraints().apply {
+        gridx = 0
+        gridy = gridRow
+        weightx = 1.0
+        fill = GridBagConstraints.HORIZONTAL
+        anchor = GridBagConstraints.NORTHWEST
+        insets = Insets(0, 0, bottomInset, 0)
+    }
+
+private fun rowConstraints(gridRow: Int): GridBagConstraints =
+    GridBagConstraints().apply {
+        gridx = 0
+        gridy = gridRow
+        weightx = 1.0
+        fill = GridBagConstraints.HORIZONTAL
+        anchor = GridBagConstraints.NORTHWEST
+        insets = Insets(0, 0, WalkthroughSettingsStyle.ROW_GAP, 0)
+    }
+
+private fun fillerConstraints(gridRow: Int): GridBagConstraints =
+    GridBagConstraints().apply {
+        gridx = 0
+        gridy = gridRow
+        weightx = 1.0
+        weighty = 1.0
+        fill = GridBagConstraints.BOTH
+    }
 
 private class PaletteRow(
     radioButton: JRadioButton,

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughSettingsListener.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughSettingsListener.kt
@@ -1,0 +1,14 @@
+package com.forketyfork.walkthrough
+
+import com.intellij.util.messages.Topic
+
+internal interface WalkthroughSettingsListener {
+    fun paletteChanged(palette: WalkthroughPalette)
+
+    companion object {
+        val TOPIC: Topic<WalkthroughSettingsListener> = Topic.create(
+            "Walkthrough settings changes",
+            WalkthroughSettingsListener::class.java
+        )
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -27,6 +27,15 @@
 
     <!-- Extensions defined by the plugin.
          Read more: https://plugins.jetbrains.com/docs/intellij/plugin-extension-points.html -->
+    <extensions defaultExtensionNs="com.intellij">
+        <applicationService serviceImplementation="com.forketyfork.walkthrough.WalkthroughSettings"/>
+        <applicationConfigurable
+                parentId="tools"
+                instance="com.forketyfork.walkthrough.WalkthroughSettingsConfigurable"
+                id="com.forketyfork.walkthrough.settings"
+                displayName="Walkthrough"/>
+    </extensions>
+
     <extensions defaultExtensionNs="com.intellij.mcpServer">
         <mcpToolset implementation="com.forketyfork.walkthrough.ShowWalkthroughItemsToolset"/>
     </extensions>

--- a/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughPaletteTest.kt
+++ b/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughPaletteTest.kt
@@ -1,0 +1,88 @@
+package com.forketyfork.walkthrough
+
+import androidx.compose.ui.graphics.Color
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class WalkthroughPaletteTest {
+
+    @Test
+    fun allPresetsAreAvailable() {
+        assertEquals(
+            listOf("purple", "green", "blue", "red", "orange", "teal", "pink"),
+            WalkthroughPalettes.all.map(WalkthroughPalette::id)
+        )
+    }
+
+    @Test
+    fun presetIdsAreDistinct() {
+        val ids = WalkthroughPalettes.all.map(WalkthroughPalette::id)
+
+        assertEquals(ids.size, ids.toSet().size)
+    }
+
+    @Test
+    fun defaultPaletteIsPurple() {
+        assertSame(WalkthroughPalettes.PURPLE, WalkthroughPalettes.default)
+    }
+
+    @Test
+    fun lookupReturnsPresetById() {
+        assertSame(WalkthroughPalettes.GREEN, WalkthroughPalettes.byId("green"))
+    }
+
+    @Test
+    fun lookupFallsBackToDefaultForUnknownId() {
+        assertSame(WalkthroughPalettes.PURPLE, WalkthroughPalettes.byId("unknown"))
+    }
+
+    @Test
+    fun lookupFallsBackToDefaultForMissingId() {
+        assertSame(WalkthroughPalettes.PURPLE, WalkthroughPalettes.byId(null))
+    }
+
+    @Test
+    fun purplePalettePreservesCurrentPopupBackground() {
+        assertEquals(
+            listOf(
+                WalkthroughColors.veryDarkPurple,
+                WalkthroughColors.darkPurple,
+                WalkthroughColors.magenta,
+                WalkthroughColors.navyBlue
+            ),
+            WalkthroughPalettes.PURPLE.backgroundGradientColors
+        )
+    }
+
+    @Test
+    fun purplePalettePreservesCurrentPopupGlow() {
+        assertEquals(
+            listOf(
+                WalkthroughColors.lightPink.copy(alpha = 0.4f),
+                WalkthroughColors.glowLavender,
+                Color.Transparent
+            ),
+            WalkthroughPalettes.PURPLE.glowGradientColors
+        )
+    }
+
+    @Test
+    fun purplePalettePreservesCurrentPopupBorder() {
+        assertEquals(
+            listOf(
+                WalkthroughColors.purple,
+                WalkthroughColors.pink,
+                WalkthroughColors.blue,
+                WalkthroughColors.purple
+            ),
+            WalkthroughPalettes.PURPLE.borderGradientColors
+        )
+    }
+
+    @Test
+    fun everyPresetHasSwatchColors() {
+        assertTrue(WalkthroughPalettes.all.all { it.swatchGradientColors.isNotEmpty() })
+    }
+}


### PR DESCRIPTION
## Solution

This adds a Walkthrough settings page with seven built-in popup palettes: Purple, Green, Blue, Red, Orange, Teal, and Pink. Purple stays the default, and its colors match the previous hard-coded values.

The selected palette is stored as application-level state using a stable palette ID. When a walkthrough popup opens, the orchestrator reads that palette once and passes it through the Compose content, navigation widgets, and Swing connector painting. This keeps the agreed behavior: palette changes apply to the next popup, while an already open popup is left alone.

The popup animation code is intentionally unchanged. `ANIMATION_FRAME_INTERVAL_MS`, `TimeSource.Monotonic`, `reverseLinearShift`, and `WalkthroughPopupGeometry.kt` are not touched.

Closes #8

## Test plan

- [x] Open `Settings | Tools | Walkthrough` and confirm all seven palettes appear with labelled gradient swatches.
- [x] Select a non-purple palette, apply settings, then open a walkthrough popup and confirm the popup uses that palette.
- [x] Select Purple again and confirm the popup returns to the original purple look.
