### PR TITLE
fix: wrap document access in read action

### DIFF
--- a/src/main/kotlin/com/forketyfork/walkthrough/ResolvedWalkthroughTarget.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/ResolvedWalkthroughTarget.kt
@@ -1,5 +1,6 @@
 package com.forketyfork.walkthrough
 
+import com.intellij.openapi.application.runReadActionBlocking
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.LogicalPosition
 import com.intellij.openapi.editor.ScrollType
@@ -63,8 +64,9 @@ private fun findWalkthroughFile(project: Project, relativePath: String) =
         ?.toString()
         ?.let(LocalFileSystem.getInstance()::findFileByPath)
 
-private fun VirtualFile.lineCount(): Int? =
+private fun VirtualFile.lineCount(): Int? = runReadActionBlocking {
     FileDocumentManager.getInstance().getDocument(this)?.lineCount
+}
 
 private fun openEditor(
     project: Project,


### PR DESCRIPTION
## Solution

Showing a walkthrough through the MCP tool raised `Read access is allowed from inside read-action only` the first time the popup advanced past the initial item. The orchestrator's `scheduleItemNavigation` reposts target resolution via `SwingUtilities.invokeLater`, which lacks the implicit write-intent read action that `Dispatchers.EDT` carries on the initial call. The actual read access happens in `VirtualFile.lineCount()`, where `FileDocumentManager.getInstance().getDocument(...)` requires a read action.

Wrapping that single call in `runReadActionBlocking` keeps the fix local to the place that needs read access, instead of pushing threading concerns onto every caller of `resolveWalkthroughTarget`.

No tracking issue exists; linkage will be added during cleanup if one is filed later.

## Test plan

- [x] `just run`, then trigger a walkthrough via the `show_walkthrough_items` MCP tool with at least two items where the first has a `file` field
- [x] Click **Next** to advance past the first item and confirm the IDE log no longer shows the read-access exception
- [x] Confirm the popup still positions itself near the target line and reopens the correct file
