### PR TITLE
feat: let users ask follow-up questions in the walkthrough popup

### DIFF
--- a/src/main/kotlin/com/forketyfork/walkthrough/ShowWalkthroughItemsToolset.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/ShowWalkthroughItemsToolset.kt
@@ -26,7 +26,10 @@ class ShowWalkthroughItemsToolset : McpToolset {
             "with Previous and Next buttons. The walkthrough is saved to this project's history. " +
             "Top-level items are auto-labeled '1', '2', '3', etc. " +
             "The returned message includes a walkthroughId; pass it to await_walkthrough_question " +
-            "to react to follow-up questions the user types into the popup."
+            "to react to follow-up questions the user types into the popup. " +
+            "After this tool returns, immediately call await_walkthrough_question with that walkthroughId. " +
+            "Do not stop after showing the walkthrough; the waiting tool call is required for the plugin " +
+            "to deliver user questions back to you."
     )
     suspend fun showWalkthroughItems(
         @McpDescription(
@@ -61,7 +64,9 @@ class ShowWalkthroughItemsToolset : McpToolset {
         val historySuffix = record
             ?.let { "; saved to history as ${it.id}" }
             ?: "; history was not saved"
-        return "Walkthrough shown with walkthroughId=${session.id} (steps: $labels)$historySuffix"
+        return "Walkthrough shown with walkthroughId=${session.id} (steps: $labels)$historySuffix. " +
+            "Next: immediately call await_walkthrough_question with walkthroughId=${session.id} " +
+            "and keep waiting for questions until it returns dismissed."
     }
 
     @Suppress("unused")
@@ -70,8 +75,9 @@ class ShowWalkthroughItemsToolset : McpToolset {
         "Suspends until the user types a follow-up question into the active walkthrough popup " +
             "and presses Send, then returns the question text along with the label of the step " +
             "the user was viewing. Returns 'dismissed' if the user closes the popup before asking. " +
-            "Call this in a loop after show_walkthrough_items to react to questions; call " +
-            "insert_walkthrough_tangents to splice the answer into the walkthrough as labeled child steps."
+            "Call this immediately after show_walkthrough_items returns, and call it again after each " +
+            "insert_walkthrough_tangents response. Keep waiting in this loop until this tool returns dismissed. " +
+            "Call insert_walkthrough_tangents to splice each answer into the walkthrough as labeled child steps."
     )
     suspend fun awaitWalkthroughQuestion(
         @McpDescription("The walkthroughId returned by show_walkthrough_items.") walkthroughId: String
@@ -99,7 +105,8 @@ class ShowWalkthroughItemsToolset : McpToolset {
             "New child labels are derived automatically by appending '.N' to the parent label: " +
             "the first tangent under '3' becomes '3.1', the next '3.2', and so on. The popup " +
             "auto-navigates to the first inserted step. Clears the inline loading spinner so " +
-            "the user can ask another question."
+            "the user can ask another question. After this tool returns, immediately call " +
+            "await_walkthrough_question again with the same walkthroughId."
     )
     suspend fun insertWalkthroughTangents(
         @McpDescription("The walkthroughId returned by show_walkthrough_items.") walkthroughId: String,

--- a/src/main/kotlin/com/forketyfork/walkthrough/ShowWalkthroughItemsToolset.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/ShowWalkthroughItemsToolset.kt
@@ -9,6 +9,7 @@ import com.intellij.mcpserver.annotations.McpTool
 import com.intellij.mcpserver.mcpFail
 import com.intellij.mcpserver.projectOrNull
 import com.intellij.openapi.application.EDT
+import com.intellij.openapi.project.Project
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.withContext
@@ -22,7 +23,10 @@ class ShowWalkthroughItemsToolset : McpToolset {
     @McpDescription(
         "Shows and stores walkthrough items with navigation support. " +
             "Accepts one or more walkthrough items; the user can cycle through them " +
-            "with Previous and Next buttons. The walkthrough is saved to this project's history."
+            "with Previous and Next buttons. The walkthrough is saved to this project's history. " +
+            "Top-level items are auto-labeled '1', '2', '3', etc. " +
+            "The returned message includes a walkthroughId; pass it to await_walkthrough_question " +
+            "to react to follow-up questions the user types into the popup."
     )
     suspend fun showWalkthroughItems(
         @McpDescription(
@@ -37,39 +41,102 @@ class ShowWalkthroughItemsToolset : McpToolset {
             "Verify line numbers by reading the actual file before calling this tool — do not estimate from diffs or memory."
         ) items: String
     ): String {
-        val project = currentCoroutineContext().projectOrNull
-            ?: mcpFail("No active project")
+        val project = requireProject()
         val trimmedDescription = description.trim()
         if (trimmedDescription.isBlank()) mcpFail("description must not be blank")
 
-        val itemList = try {
-            val type = object : TypeToken<List<WalkthroughItemJson>>() {}.type
-            val parsed: List<WalkthroughItemJson> = Gson().fromJson(items, type)
-            parsed.map { entry ->
-                WalkthroughItem(
-                    text = entry.text ?: mcpFail("Each item must have a 'text' field"),
-                    file = entry.file,
-                    line = entry.line
-                )
-            }
-        } catch (exception: JsonParseException) {
-            mcpFail("Invalid entries JSON: ${exception.message}")
-        } catch (exception: IllegalStateException) {
-            mcpFail("Invalid entries JSON: ${exception.message}")
-        }
+        val parsedItems = parseItems(items)
+        if (parsedItems.isEmpty()) mcpFail("items must not be empty")
 
-        if (itemList.isEmpty()) mcpFail("items must not be empty")
+        val labeledItems = assignTopLevelLabels(parsedItems)
 
-        val shown = withContext(Dispatchers.EDT) {
-            showWalkthroughItems(project, itemList)
-        }
-        if (!shown) mcpFail("No active editor")
+        val session = withContext(Dispatchers.EDT) {
+            showWalkthroughSession(project, labeledItems, acceptsQuestions = true)
+        } ?: mcpFail("No active editor")
 
         val record = WalkthroughHistoryService.getInstance(project)
-            .save(trimmedDescription, itemList)
+            .save(trimmedDescription, session.snapshotItems())
 
-        return record
-            ?.let { savedRecord -> "Walkthrough items shown and saved as ${savedRecord.id}" }
-            ?: "Walkthrough items shown; history was not saved"
+        val labels = labeledItems.mapNotNull { it.label }.joinToString(", ")
+        val historySuffix = record
+            ?.let { "; saved to history as ${it.id}" }
+            ?: "; history was not saved"
+        return "Walkthrough shown with walkthroughId=${session.id} (steps: $labels)$historySuffix"
+    }
+
+    @Suppress("unused")
+    @McpTool(name = "await_walkthrough_question")
+    @McpDescription(
+        "Suspends until the user types a follow-up question into the active walkthrough popup " +
+            "and presses Send, then returns the question text along with the label of the step " +
+            "the user was viewing. Returns 'dismissed' if the user closes the popup before asking. " +
+            "Call this in a loop after show_walkthrough_items to react to questions; call " +
+            "insert_walkthrough_tangents to splice the answer into the walkthrough as labeled child steps."
+    )
+    suspend fun awaitWalkthroughQuestion(
+        @McpDescription("The walkthroughId returned by show_walkthrough_items.") walkthroughId: String
+    ): String {
+        val project = requireProject()
+        val session = WalkthroughSessionRegistry.getInstance(project).get(walkthroughId)
+            ?: mcpFail("Unknown walkthroughId: $walkthroughId")
+        val question = session.awaitQuestion()
+            ?: return "dismissed"
+        val parent = question.parentLabel ?: "(unknown)"
+        return "parentLabel=$parent\nquestion=${question.question}"
+    }
+
+    @Suppress("unused")
+    @McpTool(name = "insert_walkthrough_tangents")
+    @McpDescription(
+        "Inserts one or more answer steps as children of an existing walkthrough step. " +
+            "New child labels are derived automatically by appending '.N' to the parent label: " +
+            "the first tangent under '3' becomes '3.1', the next '3.2', and so on. The popup " +
+            "auto-navigates to the first inserted step. Clears the inline loading spinner so " +
+            "the user can ask another question."
+    )
+    suspend fun insertWalkthroughTangents(
+        @McpDescription("The walkthroughId returned by show_walkthrough_items.") walkthroughId: String,
+        @McpDescription(
+            "Label of the parent step the user asked the question under (e.g. '3' or '3.1'). " +
+            "Must match the parentLabel reported by await_walkthrough_question."
+        ) parentLabel: String,
+        @McpDescription(
+            "JSON array of walkthrough items to insert as children, same shape as show_walkthrough_items: " +
+            "[{\"text\":\"…\",\"file\":\"src/Foo.kt\",\"line\":10}, …]. " +
+            "Verify line numbers against the actual file before calling."
+        ) items: String
+    ): String {
+        val project = requireProject()
+        val trimmedParent = parentLabel.trim()
+        if (trimmedParent.isBlank()) mcpFail("parentLabel must not be blank")
+        val session = WalkthroughSessionRegistry.getInstance(project).get(walkthroughId)
+            ?: mcpFail("Unknown walkthroughId: $walkthroughId")
+        val parsedItems = parseItems(items)
+        if (parsedItems.isEmpty()) mcpFail("items must not be empty")
+
+        val inserted = withContext(Dispatchers.EDT) {
+            session.insertTangents(trimmedParent, parsedItems)
+        }
+        val labels = inserted.mapNotNull { it.label }.joinToString(", ")
+        return "Inserted ${inserted.size} tangent step(s) under $trimmedParent: $labels"
+    }
+
+    private suspend fun requireProject(): Project =
+        currentCoroutineContext().projectOrNull ?: mcpFail("No active project")
+
+    private fun parseItems(items: String): List<WalkthroughItem> = try {
+        val type = object : TypeToken<List<WalkthroughItemJson>>() {}.type
+        val parsed: List<WalkthroughItemJson> = Gson().fromJson(items, type)
+        parsed.map { entry ->
+            WalkthroughItem(
+                text = entry.text ?: mcpFail("Each item must have a 'text' field"),
+                file = entry.file,
+                line = entry.line
+            )
+        }
+    } catch (exception: JsonParseException) {
+        mcpFail("Invalid items JSON: ${exception.message}")
+    } catch (exception: IllegalStateException) {
+        mcpFail("Invalid items JSON: ${exception.message}")
     }
 }

--- a/src/main/kotlin/com/forketyfork/walkthrough/ShowWalkthroughItemsToolset.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/ShowWalkthroughItemsToolset.kt
@@ -77,12 +77,19 @@ class ShowWalkthroughItemsToolset : McpToolset {
         @McpDescription("The walkthroughId returned by show_walkthrough_items.") walkthroughId: String
     ): String {
         val project = requireProject()
-        val session = WalkthroughSessionRegistry.getInstance(project).get(walkthroughId)
-            ?: mcpFail("Unknown walkthroughId: $walkthroughId")
-        val question = session.awaitQuestion()
-            ?: return "dismissed"
-        val parent = question.parentLabel ?: "(unknown)"
-        return "parentLabel=$parent\nquestion=${question.question}"
+        val registry = WalkthroughSessionRegistry.getInstance(project)
+        val session = registry.get(walkthroughId)
+        val question = when {
+            session != null -> session.awaitQuestion().also {
+                registry.consumeDismissed(walkthroughId)
+            }
+            registry.consumeDismissed(walkthroughId) -> null
+            else -> mcpFail("Unknown walkthroughId: $walkthroughId")
+        }
+        return question?.let {
+            val parent = it.parentLabel ?: "(unknown)"
+            "parentLabel=$parent\nquestion=${it.question}"
+        } ?: "dismissed"
     }
 
     @Suppress("unused")

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughHistoryStore.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughHistoryStore.kt
@@ -38,7 +38,9 @@ private data class WalkthroughRecordJson(
 private data class WalkthroughRecordItemJson(
     val text: String?,
     val file: String?,
-    val line: Int?
+    val line: Int?,
+    val label: String?,
+    val parentLabel: String?
 )
 
 internal class WalkthroughHistoryStore(
@@ -197,4 +199,12 @@ private fun WalkthroughRecordJson.toRecord(): WalkthroughRecord? {
 private fun WalkthroughRecordItemJson.toWalkthroughItemOrNull(): WalkthroughItem? =
     text
         ?.takeIf { value -> value.isNotBlank() }
-        ?.let { value -> WalkthroughItem(text = value, file = file, line = line) }
+        ?.let { value ->
+            WalkthroughItem(
+                text = value,
+                file = file,
+                line = line,
+                label = label?.takeIf { it.isNotBlank() },
+                parentLabel = parentLabel?.takeIf { it.isNotBlank() }
+            )
+        }

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughItem.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughItem.kt
@@ -16,5 +16,7 @@ internal object WalkthroughPopupLayout {
 data class WalkthroughItem(
     val text: String,
     val file: String? = null,
-    val line: Int? = null
+    val line: Int? = null,
+    val label: String? = null,
+    val parentLabel: String? = null
 )

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughOrchestrator.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughOrchestrator.kt
@@ -1,6 +1,7 @@
 package com.forketyfork.walkthrough
 
 import androidx.compose.runtime.mutableStateOf
+import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.fileEditor.FileEditorManager
@@ -47,6 +48,14 @@ fun showWalkthroughSession(
 
     val registry = WalkthroughSessionRegistry.getInstance(project)
     val session = registry.create(items, acceptsQuestions)
+    Disposer.register(
+        sessionDisposable,
+        object : Disposable {
+            override fun dispose() {
+                registry.remove(session.id)
+            }
+        }
+    )
 
     var popupRef: WalkthroughPopupSurface? = null
     var currentEditor = firstTarget.editor

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughOrchestrator.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughOrchestrator.kt
@@ -14,20 +14,39 @@ import java.awt.Dimension
 import javax.swing.JComponent
 import javax.swing.SwingUtilities
 
-fun showWalkthroughItems(project: Project, items: List<WalkthroughItem>): Boolean {
+fun showWalkthroughItems(project: Project, items: List<WalkthroughItem>): Boolean =
+    showWalkthroughSession(project, items, acceptsQuestions = false) != null
+
+fun showWalkthroughItems(project: Project, editor: Editor, items: List<WalkthroughItem>): Boolean =
+    showWalkthroughSession(project, editor, items, acceptsQuestions = false) != null
+
+fun showWalkthroughSession(
+    project: Project,
+    items: List<WalkthroughItem>,
+    acceptsQuestions: Boolean
+): WalkthroughSession? {
     val fallbackEditor = FileEditorManager.getInstance(project).selectedTextEditor
     val target = items.firstOrNull()
         ?.let { item -> resolveWalkthroughTarget(project, fallbackEditor, item) }
-    return target?.let { resolved -> showWalkthroughItems(project, resolved.editor, items) } ?: false
+    return target?.let { resolved -> showWalkthroughSession(project, resolved.editor, items, acceptsQuestions) }
 }
 
-fun showWalkthroughItems(project: Project, editor: Editor, items: List<WalkthroughItem>): Boolean {
+@Suppress("LongMethod")
+fun showWalkthroughSession(
+    project: Project,
+    editor: Editor,
+    items: List<WalkthroughItem>,
+    acceptsQuestions: Boolean
+): WalkthroughSession? {
     val firstTarget = items.firstOrNull()
         ?.let { item -> resolveWalkthroughTarget(project, editor, item) }
-        ?: return false
+        ?: return null
     val paletteState = mutableStateOf(WalkthroughSettings.getInstance().selectedPalette)
     val sessionDisposable = Disposer.newCheckedDisposable("WalkthroughPopupSession")
     Disposer.register(project, sessionDisposable)
+
+    val registry = WalkthroughSessionRegistry.getInstance(project)
+    val session = registry.create(items, acceptsQuestions)
 
     var popupRef: WalkthroughPopupSurface? = null
     var currentEditor = firstTarget.editor
@@ -72,7 +91,7 @@ fun showWalkthroughItems(project: Project, editor: Editor, items: List<Walkthrou
 
     val panel = createWalkthroughPanel(
         project = project,
-        items = items,
+        session = session,
         paletteProvider = { paletteState.value },
         onItemDisplayed = ::scheduleItemNavigation,
         onNavigateToSource = ::scheduleItemNavigation,
@@ -110,6 +129,7 @@ fun showWalkthroughItems(project: Project, editor: Editor, items: List<Walkthrou
         palette = paletteState.value,
         onCloseRequested = {
             popupRef = null
+            registry.remove(session.id)
             Disposer.dispose(sessionDisposable)
         }
     )
@@ -117,12 +137,12 @@ fun showWalkthroughItems(project: Project, editor: Editor, items: List<Walkthrou
     Disposer.register(sessionDisposable, popup)
     popup.update(currentEditor, firstTarget.popupItem)
     movePopupNearItem(popup, currentEditor, firstTarget.popupItem, ::repaintPopup)
-    return true
+    return session
 }
 
 private fun createWalkthroughPanel(
     project: Project,
-    items: List<WalkthroughItem>,
+    session: WalkthroughSession,
     paletteProvider: () -> WalkthroughPalette,
     onItemDisplayed: (WalkthroughItem) -> Unit,
     onNavigateToSource: (WalkthroughItem) -> Unit,
@@ -131,7 +151,7 @@ private fun createWalkthroughPanel(
     JewelComposePanel {
         WalkthroughItemContent(
             project = project,
-            items = items,
+            session = session,
             palette = paletteProvider(),
             onItemDisplayed = onItemDisplayed,
             onNavigateToSource = onNavigateToSource,

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupContent.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupContent.kt
@@ -106,18 +106,21 @@ private data class WalkthroughPopupAnimationState(
 @Composable
 internal fun WalkthroughItemContent(
     project: Project,
-    items: List<WalkthroughItem>,
+    session: WalkthroughSession,
     palette: WalkthroughPalette,
     onItemDisplayed: (WalkthroughItem) -> Unit,
     onNavigateToSource: (WalkthroughItem) -> Unit,
     onClose: () -> Unit
 ) {
-    var currentIndex by remember { mutableStateOf(0) }
-    val item = items[currentIndex]
+    val items = session.items
+    var currentIndex by session.currentIndexState
+    val safeIndex = currentIndex.coerceIn(0, (items.size - 1).coerceAtLeast(0))
+    val item = items.getOrNull(safeIndex) ?: return
     val scrollState = rememberScrollState()
     val animationState = rememberPopupAnimationState()
     val scrollbarStyle = rememberPopupScrollbarStyle(palette)
     val showScrollbar = scrollState.maxValue > 0
+    val isLoading by session.loadingState
 
     LaunchedEffect(item) {
         scrollState.scrollTo(0)
@@ -129,14 +132,17 @@ internal fun WalkthroughItemContent(
             project = project,
             item = item,
             items = items,
-            currentIndex = currentIndex,
+            currentIndex = safeIndex,
+            acceptsQuestions = session.acceptsQuestions,
+            isLoading = isLoading,
             palette = palette,
             scrollState = scrollState,
             showScrollbar = showScrollbar,
             animationState = animationState,
-            onPrevious = { currentIndex-- },
-            onNext = { currentIndex++ },
+            onPrevious = { currentIndex = (safeIndex - 1).coerceAtLeast(0) },
+            onNext = { currentIndex = (safeIndex + 1).coerceAtMost(items.lastIndex) },
             onNavigateToSource = { onNavigateToSource(item) },
+            onSubmitQuestion = { text -> session.submitQuestion(text) },
             onClose = onClose
         )
     }
@@ -179,12 +185,15 @@ private fun rememberPopupScrollbarStyle(palette: WalkthroughPalette): ScrollbarS
         )
     }
 
+@Suppress("LongParameterList")
 @Composable
 private fun WalkthroughPopupFrame(
     project: Project,
     item: WalkthroughItem,
     items: List<WalkthroughItem>,
     currentIndex: Int,
+    acceptsQuestions: Boolean,
+    isLoading: Boolean,
     palette: WalkthroughPalette,
     scrollState: ScrollState,
     showScrollbar: Boolean,
@@ -192,6 +201,7 @@ private fun WalkthroughPopupFrame(
     onPrevious: () -> Unit,
     onNext: () -> Unit,
     onNavigateToSource: () -> Unit,
+    onSubmitQuestion: (String) -> Unit,
     onClose: () -> Unit
 ) {
     val shape = RoundedCornerShape(WalkthroughPopupContentStyle.cornerRadius)
@@ -242,6 +252,13 @@ private fun WalkthroughPopupFrame(
                     palette = palette,
                     onPrevious = onPrevious,
                     onNext = onNext
+                )
+            }
+            if (acceptsQuestions) {
+                WalkthroughQuestionInput(
+                    isLoading = isLoading,
+                    palette = palette,
+                    onSubmit = onSubmitQuestion
                 )
             }
         }
@@ -325,22 +342,29 @@ private fun WalkthroughPopupHeader(
             )
     ) {
         AiBadge(palette)
-        if (items.size > 1) {
+        val meta = headerMetaText(item = item, items = items, currentIndex = currentIndex)
+        if (meta != null) {
             Text(
-                text = "${currentIndex + 1} / ${items.size}",
-                color = palette.metaTextColor,
-                fontSize = WalkthroughPopupContentStyle.metaTextSize,
-                fontWeight = FontWeight.Medium
-            )
-        } else if (item.line != null) {
-            Text(
-                text = "Line ${item.line}",
+                text = meta,
                 color = palette.metaTextColor,
                 fontSize = WalkthroughPopupContentStyle.metaTextSize,
                 fontWeight = FontWeight.Medium
             )
         }
     }
+}
+
+private fun headerMetaText(item: WalkthroughItem, items: List<WalkthroughItem>, currentIndex: Int): String? {
+    val label = item.label
+    val lineSuffix = item.line?.let { "Line $it" }
+    val parts = buildList {
+        when {
+            label != null -> add("Step $label")
+            items.size > 1 -> add("${currentIndex + 1} / ${items.size}")
+        }
+        if (lineSuffix != null) add(lineSuffix)
+    }
+    return parts.takeIf { it.isNotEmpty() }?.joinToString(" · ")
 }
 
 @Composable

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupWidgets.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupWidgets.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.weight
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -245,55 +244,71 @@ internal fun WalkthroughQuestionInput(
         horizontalArrangement = Arrangement.spacedBy(WalkthroughWidgetStyle.questionRowSpacing),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Box(
-            modifier = Modifier
-                .weight(1f)
-                .clip(RoundedCornerShape(WalkthroughWidgetStyle.questionFieldRadius))
-                .background(
-                    Color.White.copy(alpha = WalkthroughWidgetStyle.QUESTION_FIELD_BACKGROUND_ALPHA),
-                    RoundedCornerShape(WalkthroughWidgetStyle.questionFieldRadius)
-                )
-                .border(
-                    WalkthroughWidgetStyle.closeButtonBorderWidth,
-                    Color.White.copy(alpha = WalkthroughWidgetStyle.QUESTION_FIELD_BORDER_ALPHA),
-                    RoundedCornerShape(WalkthroughWidgetStyle.questionFieldRadius)
-                )
-                .padding(
-                    horizontal = WalkthroughWidgetStyle.questionFieldPaddingHorizontal,
-                    vertical = WalkthroughWidgetStyle.questionFieldPaddingVertical
-                )
-        ) {
-            BasicTextField(
-                value = text,
-                onValueChange = { value -> text = value },
-                enabled = !isLoading,
-                singleLine = true,
-                textStyle = TextStyle(
-                    color = Color.White,
-                    fontSize = WalkthroughWidgetStyle.questionFieldTextSize,
-                    fontWeight = FontWeight.Normal
-                ),
-                cursorBrush = SolidColor(Color.White),
-                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Send),
-                keyboardActions = KeyboardActions(onSend = { submit() }),
-                modifier = Modifier.fillMaxWidth(),
-                decorationBox = { innerTextField ->
-                    if (text.isEmpty()) {
-                        Text(
-                            text = "Ask a question about this step…",
-                            color = Color.White.copy(alpha = WalkthroughWidgetStyle.QUESTION_PLACEHOLDER_ALPHA),
-                            fontSize = WalkthroughWidgetStyle.questionFieldTextSize
-                        )
-                    }
-                    innerTextField()
-                }
-            )
-        }
+        QuestionTextField(
+            text = text,
+            isLoading = isLoading,
+            onTextChange = { value -> text = value },
+            onSend = submit,
+            modifier = Modifier.weight(1f)
+        )
         if (isLoading) {
             QuestionSpinner(palette = palette)
         } else {
             SendQuestionButton(enabled = canSubmit, palette = palette, onClick = submit)
         }
+    }
+}
+
+@Composable
+private fun QuestionTextField(
+    text: String,
+    isLoading: Boolean,
+    onTextChange: (String) -> Unit,
+    onSend: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(WalkthroughWidgetStyle.questionFieldRadius))
+            .background(
+                Color.White.copy(alpha = WalkthroughWidgetStyle.QUESTION_FIELD_BACKGROUND_ALPHA),
+                RoundedCornerShape(WalkthroughWidgetStyle.questionFieldRadius)
+            )
+            .border(
+                WalkthroughWidgetStyle.closeButtonBorderWidth,
+                Color.White.copy(alpha = WalkthroughWidgetStyle.QUESTION_FIELD_BORDER_ALPHA),
+                RoundedCornerShape(WalkthroughWidgetStyle.questionFieldRadius)
+            )
+            .padding(
+                horizontal = WalkthroughWidgetStyle.questionFieldPaddingHorizontal,
+                vertical = WalkthroughWidgetStyle.questionFieldPaddingVertical
+            )
+    ) {
+        BasicTextField(
+            value = text,
+            onValueChange = onTextChange,
+            enabled = !isLoading,
+            singleLine = true,
+            textStyle = TextStyle(
+                color = Color.White,
+                fontSize = WalkthroughWidgetStyle.questionFieldTextSize,
+                fontWeight = FontWeight.Normal
+            ),
+            cursorBrush = SolidColor(Color.White),
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Send),
+            keyboardActions = KeyboardActions(onSend = { onSend() }),
+            modifier = Modifier.fillMaxWidth(),
+            decorationBox = { innerTextField ->
+                if (text.isEmpty()) {
+                    Text(
+                        text = "Ask a question about this step…",
+                        color = Color.White.copy(alpha = WalkthroughWidgetStyle.QUESTION_PLACEHOLDER_ALPHA),
+                        fontSize = WalkthroughWidgetStyle.questionFieldTextSize
+                    )
+                }
+                innerTextField()
+            }
+        )
     }
 }
 

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupWidgets.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupWidgets.kt
@@ -1,25 +1,49 @@
 package com.forketyfork.walkthrough
 
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.weight
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.foundation.Canvas
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.drawscope.DrawScope
 import org.jetbrains.jewel.ui.component.Icon
 import org.jetbrains.jewel.ui.component.Text
 import org.jetbrains.jewel.ui.icons.AllIconsKeys
@@ -42,6 +66,20 @@ private object WalkthroughWidgetStyle {
     val navHorizontalPadding = 14.dp
     val navVerticalPadding = 8.dp
     val navTextSize = 13.sp
+    val questionRowSpacing = 8.dp
+    val questionFieldRadius = 18.dp
+    val questionFieldPaddingHorizontal = 14.dp
+    val questionFieldPaddingVertical = 10.dp
+    val questionFieldTextSize = 13.sp
+    const val QUESTION_FIELD_BACKGROUND_ALPHA = 0.12f
+    const val QUESTION_FIELD_BORDER_ALPHA = 0.2f
+    const val QUESTION_PLACEHOLDER_ALPHA = 0.55f
+    val sendButtonSize = 34.dp
+    val spinnerSize = 18.dp
+    val spinnerStrokeWidth = 2.dp
+    const val SPINNER_SWEEP_DEGREES = 270f
+    const val SPINNER_ROTATION_DURATION_MS = 1000
+    const val SPINNER_TRACK_ALPHA = 0.18f
 }
 
 @Composable
@@ -186,4 +224,149 @@ internal fun AiNavButton(
             style = textStyle
         )
     }
+}
+
+@Composable
+internal fun WalkthroughQuestionInput(
+    isLoading: Boolean,
+    palette: WalkthroughPalette,
+    onSubmit: (String) -> Unit
+) {
+    var text by remember { mutableStateOf("") }
+    val canSubmit = !isLoading && text.isNotBlank()
+    val submit: () -> Unit = {
+        if (canSubmit) {
+            onSubmit(text)
+            text = ""
+        }
+    }
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(WalkthroughWidgetStyle.questionRowSpacing),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .clip(RoundedCornerShape(WalkthroughWidgetStyle.questionFieldRadius))
+                .background(
+                    Color.White.copy(alpha = WalkthroughWidgetStyle.QUESTION_FIELD_BACKGROUND_ALPHA),
+                    RoundedCornerShape(WalkthroughWidgetStyle.questionFieldRadius)
+                )
+                .border(
+                    WalkthroughWidgetStyle.closeButtonBorderWidth,
+                    Color.White.copy(alpha = WalkthroughWidgetStyle.QUESTION_FIELD_BORDER_ALPHA),
+                    RoundedCornerShape(WalkthroughWidgetStyle.questionFieldRadius)
+                )
+                .padding(
+                    horizontal = WalkthroughWidgetStyle.questionFieldPaddingHorizontal,
+                    vertical = WalkthroughWidgetStyle.questionFieldPaddingVertical
+                )
+        ) {
+            BasicTextField(
+                value = text,
+                onValueChange = { value -> text = value },
+                enabled = !isLoading,
+                singleLine = true,
+                textStyle = TextStyle(
+                    color = Color.White,
+                    fontSize = WalkthroughWidgetStyle.questionFieldTextSize,
+                    fontWeight = FontWeight.Normal
+                ),
+                cursorBrush = SolidColor(Color.White),
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Send),
+                keyboardActions = KeyboardActions(onSend = { submit() }),
+                modifier = Modifier.fillMaxWidth(),
+                decorationBox = { innerTextField ->
+                    if (text.isEmpty()) {
+                        Text(
+                            text = "Ask a question about this step…",
+                            color = Color.White.copy(alpha = WalkthroughWidgetStyle.QUESTION_PLACEHOLDER_ALPHA),
+                            fontSize = WalkthroughWidgetStyle.questionFieldTextSize
+                        )
+                    }
+                    innerTextField()
+                }
+            )
+        }
+        if (isLoading) {
+            QuestionSpinner(palette = palette)
+        } else {
+            SendQuestionButton(enabled = canSubmit, palette = palette, onClick = submit)
+        }
+    }
+}
+
+@Composable
+private fun SendQuestionButton(enabled: Boolean, palette: WalkthroughPalette, onClick: () -> Unit) {
+    val backgroundBrush = Brush.linearGradient(palette.navPrimaryGradientColors)
+    Box(
+        modifier = Modifier
+            .size(WalkthroughWidgetStyle.sendButtonSize)
+            .clip(CircleShape)
+            .background(backgroundBrush, CircleShape)
+            .border(WalkthroughWidgetStyle.closeButtonBorderWidth, palette.navPrimaryBorderColor, CircleShape)
+            .clickable(enabled = enabled, onClick = onClick),
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(
+            key = AllIconsKeys.Actions.Forward,
+            contentDescription = "Send question",
+            tint = Color.White.copy(
+                alpha = if (enabled) 1f else WalkthroughWidgetStyle.NAV_TEXT_DISABLED_ALPHA
+            )
+        )
+    }
+}
+
+@Composable
+private fun QuestionSpinner(palette: WalkthroughPalette) {
+    val transition = rememberInfiniteTransition(label = "walkthrough-question-spinner")
+    val rotation by transition.animateFloat(
+        initialValue = 0f,
+        targetValue = 360f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(
+                durationMillis = WalkthroughWidgetStyle.SPINNER_ROTATION_DURATION_MS,
+                easing = LinearEasing
+            ),
+            repeatMode = RepeatMode.Restart
+        ),
+        label = "walkthrough-question-spinner-rotation"
+    )
+    Box(
+        modifier = Modifier.size(WalkthroughWidgetStyle.sendButtonSize),
+        contentAlignment = Alignment.Center
+    ) {
+        Canvas(modifier = Modifier.size(WalkthroughWidgetStyle.spinnerSize).rotate(rotation)) {
+            drawSpinnerArc(palette = palette)
+        }
+    }
+}
+
+private fun DrawScope.drawSpinnerArc(palette: WalkthroughPalette) {
+    val strokeWidthPx = WalkthroughWidgetStyle.spinnerStrokeWidth.toPx()
+    val arcSize = Size(
+        size.width - strokeWidthPx,
+        size.height - strokeWidthPx
+    )
+    val topLeft = Offset(strokeWidthPx / 2f, strokeWidthPx / 2f)
+    drawArc(
+        color = Color.White.copy(alpha = WalkthroughWidgetStyle.SPINNER_TRACK_ALPHA),
+        startAngle = 0f,
+        sweepAngle = 360f,
+        useCenter = false,
+        topLeft = topLeft,
+        size = arcSize,
+        style = Stroke(width = strokeWidthPx)
+    )
+    drawArc(
+        color = palette.navPrimaryBorderColor,
+        startAngle = 0f,
+        sweepAngle = WalkthroughWidgetStyle.SPINNER_SWEEP_DEGREES,
+        useCenter = false,
+        topLeft = topLeft,
+        size = arcSize,
+        style = Stroke(width = strokeWidthPx)
+    )
 }

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughSessionRegistry.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughSessionRegistry.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.channels.Channel
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentLinkedQueue
 
 data class WalkthroughTangentQuestion(
     val question: String,
@@ -35,38 +36,44 @@ class WalkthroughSession internal constructor(
         if (trimmed.isEmpty()) return
         val parentItem = items.getOrNull(currentIndexState.intValue)
         loadingState.value = true
-        questionChannel.trySend(WalkthroughTangentQuestion(trimmed, parentItem?.label))
+        val result = questionChannel.trySend(WalkthroughTangentQuestion(trimmed, parentItem?.label))
+        if (result.isFailure) {
+            loadingState.value = false
+        }
     }
 
     suspend fun awaitQuestion(): WalkthroughTangentQuestion? =
-        runCatching { questionChannel.receive() }.getOrNull()
+        questionChannel.receiveCatching().getOrNull()
 
     fun insertTangents(parentLabel: String, newItems: List<WalkthroughItem>): List<WalkthroughItem> {
-        require(newItems.isNotEmpty()) { "newItems must not be empty" }
-        val parentIndex = items.indexOfFirst { it.label == parentLabel }
-        require(parentIndex >= 0) { "No item with label '$parentLabel'" }
+        try {
+            require(newItems.isNotEmpty()) { "newItems must not be empty" }
+            val parentIndex = items.indexOfFirst { it.label == parentLabel }
+            require(parentIndex >= 0) { "No item with label '$parentLabel'" }
 
-        val directChildPattern = Regex("^${Regex.escape(parentLabel)}\\.\\d+$")
-        val existingDirectChildren = items.count { it.label?.matches(directChildPattern) == true }
+            val directChildPattern = Regex("^${Regex.escape(parentLabel)}\\.\\d+$")
+            val existingDirectChildren = items.count { it.label?.matches(directChildPattern) == true }
 
-        val parentPrefix = "$parentLabel."
-        var lastSubtreeIndex = parentIndex
-        items.forEachIndexed { index, item ->
-            if (item.label?.startsWith(parentPrefix) == true) {
-                lastSubtreeIndex = index
+            val parentPrefix = "$parentLabel."
+            var lastSubtreeIndex = parentIndex
+            items.forEachIndexed { index, item ->
+                if (item.label?.startsWith(parentPrefix) == true) {
+                    lastSubtreeIndex = index
+                }
             }
-        }
 
-        val labeled = newItems.mapIndexed { offset, item ->
-            item.copy(
-                label = "$parentLabel.${existingDirectChildren + offset + 1}",
-                parentLabel = parentLabel
-            )
+            val labeled = newItems.mapIndexed { offset, item ->
+                item.copy(
+                    label = "$parentLabel.${existingDirectChildren + offset + 1}",
+                    parentLabel = parentLabel
+                )
+            }
+            items.addAll(lastSubtreeIndex + 1, labeled)
+            currentIndexState.intValue = lastSubtreeIndex + 1
+            return labeled
+        } finally {
+            loadingState.value = false
         }
-        items.addAll(lastSubtreeIndex + 1, labeled)
-        currentIndexState.intValue = lastSubtreeIndex + 1
-        loadingState.value = false
-        return labeled
     }
 
     internal fun dismiss() {
@@ -79,6 +86,8 @@ class WalkthroughSession internal constructor(
 
 class WalkthroughSessionRegistry {
     private val sessions = ConcurrentHashMap<String, WalkthroughSession>()
+    private val dismissedSessionIds = ConcurrentHashMap.newKeySet<String>()
+    private val dismissedSessionOrder = ConcurrentLinkedQueue<String>()
 
     internal fun create(items: List<WalkthroughItem>, acceptsQuestions: Boolean): WalkthroughSession {
         val session = WalkthroughSession(
@@ -92,11 +101,26 @@ class WalkthroughSessionRegistry {
 
     fun get(id: String): WalkthroughSession? = sessions[id]
 
+    internal fun consumeDismissed(id: String): Boolean = dismissedSessionIds.remove(id)
+
     internal fun remove(id: String) {
-        sessions.remove(id)?.dismiss()
+        val session = sessions.remove(id) ?: return
+        session.dismiss()
+        rememberDismissed(id)
+    }
+
+    private fun rememberDismissed(id: String) {
+        if (dismissedSessionIds.add(id)) {
+            dismissedSessionOrder.add(id)
+        }
+        while (dismissedSessionIds.size > MAX_DISMISSED_SESSIONS) {
+            dismissedSessionOrder.poll()?.let(dismissedSessionIds::remove) ?: break
+        }
     }
 
     companion object {
+        private const val MAX_DISMISSED_SESSIONS = 128
+
         fun getInstance(project: Project): WalkthroughSessionRegistry =
             project.getService(WalkthroughSessionRegistry::class.java)
     }

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughSessionRegistry.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughSessionRegistry.kt
@@ -1,0 +1,108 @@
+package com.forketyfork.walkthrough
+
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import com.intellij.openapi.project.Project
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.channels.Channel
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+
+data class WalkthroughTangentQuestion(
+    val question: String,
+    val parentLabel: String?
+)
+
+class WalkthroughSession internal constructor(
+    val id: String,
+    initialItems: List<WalkthroughItem>,
+    internal val acceptsQuestions: Boolean
+) {
+    internal val items: SnapshotStateList<WalkthroughItem> =
+        mutableStateListOf<WalkthroughItem>().apply { addAll(initialItems) }
+    internal val currentIndexState = mutableIntStateOf(0)
+    internal val loadingState = mutableStateOf(false)
+
+    private val questionChannel = Channel<WalkthroughTangentQuestion>(capacity = Channel.UNLIMITED)
+    private val disposed = CompletableDeferred<Unit>()
+
+    fun snapshotItems(): List<WalkthroughItem> = items.toList()
+
+    internal fun submitQuestion(text: String) {
+        val trimmed = text.trim()
+        if (trimmed.isEmpty()) return
+        val parentItem = items.getOrNull(currentIndexState.intValue)
+        loadingState.value = true
+        questionChannel.trySend(WalkthroughTangentQuestion(trimmed, parentItem?.label))
+    }
+
+    suspend fun awaitQuestion(): WalkthroughTangentQuestion? =
+        runCatching { questionChannel.receive() }.getOrNull()
+
+    fun insertTangents(parentLabel: String, newItems: List<WalkthroughItem>): List<WalkthroughItem> {
+        require(newItems.isNotEmpty()) { "newItems must not be empty" }
+        val parentIndex = items.indexOfFirst { it.label == parentLabel }
+        require(parentIndex >= 0) { "No item with label '$parentLabel'" }
+
+        val directChildPattern = Regex("^${Regex.escape(parentLabel)}\\.\\d+$")
+        val existingDirectChildren = items.count { it.label?.matches(directChildPattern) == true }
+
+        val parentPrefix = "$parentLabel."
+        var lastSubtreeIndex = parentIndex
+        items.forEachIndexed { index, item ->
+            if (item.label?.startsWith(parentPrefix) == true) {
+                lastSubtreeIndex = index
+            }
+        }
+
+        val labeled = newItems.mapIndexed { offset, item ->
+            item.copy(
+                label = "$parentLabel.${existingDirectChildren + offset + 1}",
+                parentLabel = parentLabel
+            )
+        }
+        items.addAll(lastSubtreeIndex + 1, labeled)
+        currentIndexState.intValue = lastSubtreeIndex + 1
+        loadingState.value = false
+        return labeled
+    }
+
+    internal fun dismiss() {
+        if (disposed.complete(Unit)) {
+            loadingState.value = false
+            questionChannel.close()
+        }
+    }
+}
+
+class WalkthroughSessionRegistry {
+    private val sessions = ConcurrentHashMap<String, WalkthroughSession>()
+
+    internal fun create(items: List<WalkthroughItem>, acceptsQuestions: Boolean): WalkthroughSession {
+        val session = WalkthroughSession(
+            id = UUID.randomUUID().toString(),
+            initialItems = items,
+            acceptsQuestions = acceptsQuestions
+        )
+        sessions[session.id] = session
+        return session
+    }
+
+    fun get(id: String): WalkthroughSession? = sessions[id]
+
+    internal fun remove(id: String) {
+        sessions.remove(id)?.dismiss()
+    }
+
+    companion object {
+        fun getInstance(project: Project): WalkthroughSessionRegistry =
+            project.getService(WalkthroughSessionRegistry::class.java)
+    }
+}
+
+internal fun assignTopLevelLabels(items: List<WalkthroughItem>): List<WalkthroughItem> =
+    items.mapIndexed { index, item ->
+        item.copy(label = item.label ?: (index + 1).toString(), parentLabel = null)
+    }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -30,6 +30,7 @@
     <extensions defaultExtensionNs="com.intellij">
         <applicationService serviceImplementation="com.forketyfork.walkthrough.WalkthroughSettings"/>
         <projectService serviceImplementation="com.forketyfork.walkthrough.WalkthroughHistoryService"/>
+        <projectService serviceImplementation="com.forketyfork.walkthrough.WalkthroughSessionRegistry"/>
         <applicationConfigurable
                 parentId="tools"
                 instance="com.forketyfork.walkthrough.WalkthroughSettingsConfigurable"

--- a/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughSessionRegistryTest.kt
+++ b/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughSessionRegistryTest.kt
@@ -1,0 +1,130 @@
+package com.forketyfork.walkthrough
+
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+
+class WalkthroughSessionRegistryTest {
+    private fun newSession(items: List<WalkthroughItem>) =
+        WalkthroughSession(
+            id = "test-session",
+            initialItems = items,
+            acceptsQuestions = true
+        )
+
+    @Test
+    fun assignsAutoLabelsFromOrdinalPosition() {
+        val labeled = assignTopLevelLabels(
+            listOf(
+                WalkthroughItem(text = "a"),
+                WalkthroughItem(text = "b"),
+                WalkthroughItem(text = "c")
+            )
+        )
+        assertEquals(listOf("1", "2", "3"), labeled.map { it.label })
+    }
+
+    @Test
+    fun insertsFirstTangentImmediatelyAfterParent() {
+        val session = newSession(
+            assignTopLevelLabels(
+                listOf(
+                    WalkthroughItem(text = "one"),
+                    WalkthroughItem(text = "two"),
+                    WalkthroughItem(text = "three")
+                )
+            )
+        )
+
+        val inserted = session.insertTangents("2", listOf(WalkthroughItem(text = "answer A")))
+
+        assertEquals(listOf("2.1"), inserted.map { it.label })
+        assertEquals("2", inserted.single().parentLabel)
+        assertEquals(
+            listOf("1", "2", "2.1", "3"),
+            session.snapshotItems().map { it.label }
+        )
+        assertEquals(2, session.currentIndexState.intValue)
+    }
+
+    @Test
+    fun appendsNewTangentAfterExistingSubtree() {
+        val session = newSession(
+            assignTopLevelLabels(
+                listOf(
+                    WalkthroughItem(text = "one"),
+                    WalkthroughItem(text = "two"),
+                    WalkthroughItem(text = "three")
+                )
+            )
+        )
+        session.insertTangents("2", listOf(WalkthroughItem(text = "answer A")))
+        session.insertTangents("2.1", listOf(WalkthroughItem(text = "deeper")))
+
+        // Now ask under "2" again — should land after the entire "2.*" subtree.
+        val second = session.insertTangents("2", listOf(WalkthroughItem(text = "answer B")))
+
+        assertEquals(listOf("2.2"), second.map { it.label })
+        assertEquals(
+            listOf("1", "2", "2.1", "2.1.1", "2.2", "3"),
+            session.snapshotItems().map { it.label }
+        )
+    }
+
+    @Test
+    fun nestedTangentsUseHierarchicalLabels() {
+        val session = newSession(
+            assignTopLevelLabels(listOf(WalkthroughItem(text = "root")))
+        )
+        session.insertTangents("1", listOf(WalkthroughItem(text = "child")))
+        val grandchild = session.insertTangents("1.1", listOf(WalkthroughItem(text = "grandchild")))
+
+        assertEquals("1.1.1", grandchild.single().label)
+        assertEquals("1.1", grandchild.single().parentLabel)
+        assertEquals(
+            listOf("1", "1.1", "1.1.1"),
+            session.snapshotItems().map { it.label }
+        )
+    }
+
+    @Test
+    fun insertTangentsRejectsUnknownParent() {
+        val session = newSession(
+            assignTopLevelLabels(listOf(WalkthroughItem(text = "only")))
+        )
+        assertThrows(IllegalArgumentException::class.java) {
+            session.insertTangents("9", listOf(WalkthroughItem(text = "x")))
+        }
+    }
+
+    @Test
+    fun awaitQuestionReturnsNullAfterDismiss() = runBlocking {
+        val session = newSession(
+            assignTopLevelLabels(listOf(WalkthroughItem(text = "only")))
+        )
+        session.dismiss()
+        assertNull(session.awaitQuestion())
+    }
+
+    @Test
+    fun submitQuestionDeliversParentLabelOfCurrentItem() = runBlocking {
+        val session = newSession(
+            assignTopLevelLabels(
+                listOf(
+                    WalkthroughItem(text = "one"),
+                    WalkthroughItem(text = "two")
+                )
+            )
+        )
+        session.currentIndexState.intValue = 1
+        session.submitQuestion("what about two?")
+
+        val question = session.awaitQuestion()
+        assertNotNull(question)
+        assertEquals("2", question?.parentLabel)
+        assertEquals("what about two?", question?.question)
+    }
+}

--- a/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughSessionRegistryTest.kt
+++ b/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughSessionRegistryTest.kt
@@ -101,6 +101,20 @@ class WalkthroughSessionRegistryTest {
     }
 
     @Test
+    fun insertTangentsClearsLoadingAfterValidationFailure() {
+        val session = newSession(
+            assignTopLevelLabels(listOf(WalkthroughItem(text = "only")))
+        )
+        session.loadingState.value = true
+
+        assertThrows(IllegalArgumentException::class.java) {
+            session.insertTangents("9", listOf(WalkthroughItem(text = "x")))
+        }
+
+        assertEquals(false, session.loadingState.value)
+    }
+
+    @Test
     fun awaitQuestionReturnsNullAfterDismiss() = runBlocking {
         val session = newSession(
             assignTopLevelLabels(listOf(WalkthroughItem(text = "only")))
@@ -126,5 +140,32 @@ class WalkthroughSessionRegistryTest {
         assertNotNull(question)
         assertEquals("2", question?.parentLabel)
         assertEquals("what about two?", question?.question)
+    }
+
+    @Test
+    fun submitQuestionClearsLoadingWhenChannelIsClosed() {
+        val session = newSession(
+            assignTopLevelLabels(listOf(WalkthroughItem(text = "only")))
+        )
+        session.dismiss()
+
+        session.submitQuestion("what now?")
+
+        assertEquals(false, session.loadingState.value)
+    }
+
+    @Test
+    fun removeKeepsDismissedSessionQueryableUntilConsumed() {
+        val registry = WalkthroughSessionRegistry()
+        val session = registry.create(
+            items = assignTopLevelLabels(listOf(WalkthroughItem(text = "only"))),
+            acceptsQuestions = true
+        )
+
+        registry.remove(session.id)
+
+        assertNull(registry.get(session.id))
+        assertEquals(true, registry.consumeDismissed(session.id))
+        assertEquals(false, registry.consumeDismissed(session.id))
     }
 }


### PR DESCRIPTION
Adds an inline question input to the popup that streams user-typed
questions back to the MCP client and splices the agent's answer into
the walkthrough as labeled child steps.

- New WalkthroughSession + WalkthroughSessionRegistry project service
  hold the live items list as a SnapshotStateList so insertions
  re-render reactively, plus a Channel that buffers questions until
  the agent calls awaitQuestion.
- WalkthroughItem gains label / parentLabel; show_walkthrough_items
  auto-numbers top-level items "1", "2", "3", and insertTangents
  derives child labels by appending ".N" to the parent label.
- Two new MCP tools: await_walkthrough_question suspends until the
  user clicks Send (or returns "dismissed" on close);
  insert_walkthrough_tangents inserts the answer below the parent
  subtree and auto-navigates to the first new step.
- Popup gains a TextField + send button (BasicTextField styled to
  match the popup) with a circular spinner shown while the agent
  works.
- History store round-trips the new label fields.

Tests cover the labeling/insertion logic and the question channel.
The Gradle build cannot be run in this sandbox (download.jetbrains.com
returns 403), so just lint && just build was not executed locally — CI
will verify.