### PR TITLE
Enforce single visible walkthrough at a time

### DIFF
--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughOrchestrator.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughOrchestrator.kt
@@ -47,12 +47,14 @@ fun showWalkthroughSession(
     Disposer.register(project, sessionDisposable)
 
     val registry = WalkthroughSessionRegistry.getInstance(project)
+    registry.swapActive(sessionDisposable)?.let(Disposer::dispose)
     val session = registry.create(items, acceptsQuestions)
     Disposer.register(
         sessionDisposable,
         object : Disposable {
             override fun dispose() {
                 registry.remove(session.id)
+                registry.clearActive(sessionDisposable)
             }
         }
     )

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughSessionRegistry.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughSessionRegistry.kt
@@ -4,12 +4,14 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.snapshots.SnapshotStateList
+import com.intellij.openapi.Disposable
 import com.intellij.openapi.project.Project
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.channels.Channel
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicReference
 
 data class WalkthroughTangentQuestion(
     val question: String,
@@ -88,6 +90,14 @@ class WalkthroughSessionRegistry {
     private val sessions = ConcurrentHashMap<String, WalkthroughSession>()
     private val dismissedSessionIds = ConcurrentHashMap.newKeySet<String>()
     private val dismissedSessionOrder = ConcurrentLinkedQueue<String>()
+    private val activeSessionDisposable = AtomicReference<Disposable?>()
+
+    internal fun swapActive(newDisposable: Disposable): Disposable? =
+        activeSessionDisposable.getAndSet(newDisposable)
+
+    internal fun clearActive(disposable: Disposable) {
+        activeSessionDisposable.compareAndSet(disposable, null)
+    }
 
     internal fun create(items: List<WalkthroughItem>, acceptsQuestions: Boolean): WalkthroughSession {
         val session = WalkthroughSession(

--- a/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughSessionRegistryTest.kt
+++ b/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughSessionRegistryTest.kt
@@ -1,9 +1,11 @@
 package com.forketyfork.walkthrough
 
+import com.intellij.openapi.Disposable
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 
@@ -152,6 +154,31 @@ class WalkthroughSessionRegistryTest {
         session.submitQuestion("what now?")
 
         assertEquals(false, session.loadingState.value)
+    }
+
+    @Test
+    fun swapActiveReturnsPreviousDisposable() {
+        val registry = WalkthroughSessionRegistry()
+        val first = Disposable {}
+        val second = Disposable {}
+
+        assertNull(registry.swapActive(first))
+        assertSame(first, registry.swapActive(second))
+        assertSame(second, registry.swapActive(Disposable {}))
+    }
+
+    @Test
+    fun clearActiveOnlyClearsWhenDisposableStillMatches() {
+        val registry = WalkthroughSessionRegistry()
+        val first = Disposable {}
+        val second = Disposable {}
+
+        registry.swapActive(first)
+        registry.swapActive(second)
+
+        // first is stale — clearing it must not evict the current active disposable
+        registry.clearActive(first)
+        assertSame(second, registry.swapActive(Disposable {}))
     }
 
     @Test


### PR DESCRIPTION
Summary

Enforce that only one walkthrough popup is visible at a time. Opening a new walkthrough — whether via the MCP show_walkthrough_items tool or via the history replay action — now closes any walkthrough that was already on screen.

Implementation

* WalkthroughSessionRegistry gains an AtomicReference<Disposable?> tracking the active session's disposable, with swapActive (atomic get-and-set) and clearActive (CAS-based) helpers.
* showWalkthroughSession swaps the new session's disposable into the active slot and disposes whatever was there before. The previous popup's existing teardown chain runs (detach from layered pane, remove session, dismiss channel), so all entry paths converge on the same close behaviour as the Escape key.
* On normal close, the registered Disposable clears the active slot via CAS, so a later session's disposable is not accidentally evicted by a stale dispose.

Test plan

* [x] WalkthroughSessionRegistryTest.swapActiveReturnsPreviousDisposable — swapActive returns the previously installed disposable (or null when slot is empty).
* [x] WalkthroughSessionRegistryTest.clearActiveOnlyClearsWhenDisposableStillMatches — clearActive is a no-op when the slot already holds a newer disposable.
* [x] ./gradlew detekt passes.
* [ ] Manual: open a walkthrough via MCP, then open another via the history menu — verify the first one disappears before the second appears.
