### PR TITLE
Fix read-action assertion on Next click in walkthrough

### DIFF
--- a/src/main/kotlin/com/forketyfork/walkthrough/ResolvedWalkthroughTarget.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/ResolvedWalkthroughTarget.kt
@@ -1,6 +1,6 @@
 package com.forketyfork.walkthrough
 
-import com.intellij.openapi.application.runReadActionBlocking
+import com.intellij.openapi.application.WriteIntentReadAction
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.LogicalPosition
 import com.intellij.openapi.editor.ScrollType
@@ -64,7 +64,7 @@ private fun findWalkthroughFile(project: Project, relativePath: String) =
         ?.toString()
         ?.let(LocalFileSystem.getInstance()::findFileByPath)
 
-private fun VirtualFile.lineCount(): Int? = runReadActionBlocking {
+private fun VirtualFile.lineCount(): Int? = WriteIntentReadAction.compute<Int?> {
     FileDocumentManager.getInstance().getDocument(this)?.lineCount
 }
 


### PR DESCRIPTION
## Summary

Fixes an `IllegalStateException` (`Read access is allowed from inside read-action only`) that intermittently fired when clicking **Next** in a walkthrough.

The crash originated from `VirtualFile.lineCount()` in `ResolvedWalkthroughTarget.kt`, which wrapped `FileDocumentManager.getDocument(VirtualFile)` in `runReadActionBlocking`. That helper delegates to `ProgressIndicatorUtils.runReadActionWithWriteActionPriorityBlocking`, which on the EDT short-circuits and runs the block without acquiring a read lock — it relied on the implicit EDT read access that the IntelliJ Platform 2026.1 threading model has removed. `FileDocumentManager.getDocument(VirtualFile)` now asserts read access, so the call throws.

## Fix

Replaced `runReadActionBlocking { … }` with `WriteIntentReadAction.compute<Int?> { … }`, which is the canonical EDT-side wrapper recommended by the platform's own error message and the 2026.1 threading guidance.

## Codebase audit

Searched for similar patterns. `FileDocumentManager.getDocument(VirtualFile)` is the only API in the plugin that performs a strict read-access assertion. Other model touches (`editor.document.lineCount`, `editor.document.getLineStartOffset`, …) go through `DocumentImpl` methods that don't assert, so they don't need wrapping.

## Test plan

- [x] `./gradlew compileKotlin` — clean, no deprecation warnings
- [x] `./gradlew detekt` — passes
- [ ] Manual: open a walkthrough, click **Next** repeatedly across items that target different files; verify no exception in the IDE log