### PR TITLE
v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.3.1]
+
+### Fixed
+
+- Popup no longer jumps after appearing; it now opens at its final position and keeps the
+  target line clear of the popup body (#19).
+- Replaced `runReadActionBlocking` with `WriteIntentReadAction` to avoid read-action assertions
+  when navigating between walkthrough steps (#17).
+- Only one walkthrough popup is visible at a time; previous sessions are disposed when a new one
+  starts (#16).
+
 ## [0.3.0]
 
 ### Added

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ org.gradle.configuration-cache=true
 # Enable Gradle Build Cache -> https://docs.gradle.org/current/userguide/build_cache.html
 org.gradle.caching=true
 kotlin.stdlib.default.dependency=false
-pluginVersion=0.3.0
+pluginVersion=0.3.1


### PR DESCRIPTION
Release v0.3.1.

### Fixed

- Popup no longer jumps after appearing; it opens at its final position and keeps the target line clear of the popup body (#19).
- Replaced `runReadActionBlocking` with `WriteIntentReadAction` to avoid read-action assertions when navigating between walkthrough steps (#17).
- Only one walkthrough popup is visible at a time; previous sessions are disposed when a new one starts (#16).

The `v0.3.1` tag has been pushed and the release workflow will run on the tag.
