### PR TITLE
Track user popup movement to prevent auto-repositioning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,8 +27,8 @@ just run              # or: ./gradlew runIde
 # Verify plugin compatibility
 just verify           # or: ./gradlew verifyPlugin
 
-# Lint (Detekt static analysis)
-just lint             # or: ./gradlew detekt
+# Lint (everything CI runs: nix flake check + Detekt)
+just lint             # or: nix flake check && ./gradlew detekt
 
 # Run unit tests
 just test             # or: ./gradlew test

--- a/docs/superpowers/plans/2026-05-18-popup-geometry-persistence.md
+++ b/docs/superpowers/plans/2026-05-18-popup-geometry-persistence.md
@@ -1,0 +1,958 @@
+# Walkthrough Popup Geometry Persistence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist the walkthrough popup's screen position and size across walkthrough sessions and IDE restarts, with overlap-avoidance and root-pane clamping reapplied on every show.
+
+**Architecture:** Extend the application-level `WalkthroughSettings` with four geometry fields and a small `PopupGeometry` data class. Add a pure `clampPopupSize` helper. Replace the in-memory `userMovedPopup` machinery in `WalkthroughOrchestrator` with a unified `applyPopupGeometryForItem` pipeline that loads persisted geometry (or falls back to `movePopupNearItem`), clamps size, runs the existing `avoidLineOverlap` + `constrainPopupScreenLocation` helpers, applies the result, and persists back when the result differs. Save geometry once from `mouseReleased` in the popup interaction handler.
+
+**Tech Stack:** Kotlin 2.3.21, IntelliJ Platform 2026.1, JUnit Jupiter, JetBrains Compose / Jewel.
+
+**Source spec:** `docs/superpowers/specs/2026-05-18-popup-geometry-persistence-design.md`.
+
+---
+
+## Task 1: Extend `WalkthroughSettings` with `PopupGeometry`
+
+**Files:**
+- Modify: `src/main/kotlin/com/forketyfork/walkthrough/WalkthroughSettings.kt`
+- Create: `src/test/kotlin/com/forketyfork/walkthrough/WalkthroughSettingsGeometryTest.kt`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/test/kotlin/com/forketyfork/walkthrough/WalkthroughSettingsGeometryTest.kt`:
+
+```kotlin
+package com.forketyfork.walkthrough
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+
+class WalkthroughSettingsGeometryTest {
+
+    @Test
+    fun loadGeometryReturnsNullWhenStateIsUnset() {
+        val settings = WalkthroughSettings()
+        assertNull(settings.loadGeometry())
+    }
+
+    @Test
+    fun saveGeometryThenLoadGeometryRoundTrips() {
+        val settings = WalkthroughSettings()
+        val geometry = PopupGeometry(x = 120, y = 240, width = 720, height = 480)
+
+        settings.saveGeometry(geometry)
+
+        assertEquals(geometry, settings.loadGeometry())
+    }
+
+    @Test
+    fun loadGeometryReturnsNullWhenAnyFieldIsSentinel() {
+        val settings = WalkthroughSettings()
+        settings.saveGeometry(PopupGeometry(x = 100, y = 100, width = 800, height = 600))
+        val state = settings.state
+        state.popupX = Int.MIN_VALUE
+
+        assertNull(settings.loadGeometry())
+    }
+
+    @Test
+    fun stateSerializationRoundTripsGeometry() {
+        val original = WalkthroughSettings()
+        original.saveGeometry(PopupGeometry(x = 10, y = 20, width = 600, height = 400))
+        val serialized = original.state
+
+        val restored = WalkthroughSettings()
+        restored.loadState(serialized)
+
+        assertEquals(
+            PopupGeometry(x = 10, y = 20, width = 600, height = 400),
+            restored.loadGeometry()
+        )
+    }
+
+    @Test
+    fun saveGeometryIsIdempotent() {
+        val settings = WalkthroughSettings()
+        val geometry = PopupGeometry(x = 1, y = 2, width = 600, height = 400)
+        settings.saveGeometry(geometry)
+        val stateBefore = settings.state
+
+        settings.saveGeometry(geometry)
+
+        assertSame(stateBefore, settings.state)
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run:
+```bash
+./gradlew test --tests com.forketyfork.walkthrough.WalkthroughSettingsGeometryTest
+```
+
+Expected: compilation failure — `PopupGeometry` is not defined, `loadGeometry()` / `saveGeometry()` / `state.popupX` do not exist.
+
+- [ ] **Step 3: Extend `WalkthroughSettings`**
+
+Replace the body of `src/main/kotlin/com/forketyfork/walkthrough/WalkthroughSettings.kt` with:
+
+```kotlin
+package com.forketyfork.walkthrough
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+
+internal data class PopupGeometry(val x: Int, val y: Int, val width: Int, val height: Int)
+
+@State(
+    name = "com.forketyfork.walkthrough.WalkthroughSettings",
+    storages = [Storage("com.forketyfork.walkthrough.settings.xml")]
+)
+internal class WalkthroughSettings : PersistentStateComponent<WalkthroughSettings.State> {
+    internal var state = State()
+        private set
+
+    var selectedPaletteId: String
+        get() = state.selectedPaletteId
+        set(value) {
+            val palette = WalkthroughPalettes.byId(value)
+            if (state.selectedPaletteId == palette.id) {
+                return
+            }
+            state.selectedPaletteId = palette.id
+            notifyPaletteChanged(palette)
+        }
+
+    val selectedPalette: WalkthroughPalette
+        get() = WalkthroughPalettes.byId(selectedPaletteId)
+
+    fun loadGeometry(): PopupGeometry? {
+        val s = state
+        if (s.popupX == Int.MIN_VALUE ||
+            s.popupY == Int.MIN_VALUE ||
+            s.popupWidth == Int.MIN_VALUE ||
+            s.popupHeight == Int.MIN_VALUE
+        ) {
+            return null
+        }
+        return PopupGeometry(s.popupX, s.popupY, s.popupWidth, s.popupHeight)
+    }
+
+    fun saveGeometry(geometry: PopupGeometry) {
+        val s = state
+        if (s.popupX == geometry.x &&
+            s.popupY == geometry.y &&
+            s.popupWidth == geometry.width &&
+            s.popupHeight == geometry.height
+        ) {
+            return
+        }
+        s.popupX = geometry.x
+        s.popupY = geometry.y
+        s.popupWidth = geometry.width
+        s.popupHeight = geometry.height
+    }
+
+    override fun getState(): State = state
+
+    override fun loadState(state: State) {
+        this.state = state
+        this.state.selectedPaletteId = WalkthroughPalettes.byId(state.selectedPaletteId).id
+    }
+
+    class State {
+        var selectedPaletteId: String = WalkthroughPalettes.default.id
+        var popupX: Int = Int.MIN_VALUE
+        var popupY: Int = Int.MIN_VALUE
+        var popupWidth: Int = Int.MIN_VALUE
+        var popupHeight: Int = Int.MIN_VALUE
+    }
+
+    private fun notifyPaletteChanged(palette: WalkthroughPalette) {
+        ApplicationManager.getApplication()
+            .messageBus
+            .syncPublisher(WalkthroughSettingsListener.TOPIC)
+            .paletteChanged(palette)
+    }
+
+    companion object {
+        fun getInstance(): WalkthroughSettings =
+            ApplicationManager.getApplication().getService(WalkthroughSettings::class.java)
+    }
+}
+```
+
+Note the change to `state`: it is now exposed as `internal var ... private set` so the geometry test can mutate a single field to verify the partial-sentinel guard. All other callers continue to use the public `loadGeometry()` / `saveGeometry()` / `selectedPaletteId` API.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run:
+```bash
+./gradlew test --tests com.forketyfork.walkthrough.WalkthroughSettingsGeometryTest
+```
+
+Expected: all 5 tests pass.
+
+- [ ] **Step 5: Run lint and build**
+
+Run:
+```bash
+just lint && just build
+```
+
+Expected: both succeed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/main/kotlin/com/forketyfork/walkthrough/WalkthroughSettings.kt \
+        src/test/kotlin/com/forketyfork/walkthrough/WalkthroughSettingsGeometryTest.kt
+git commit -m "feat: persist popup geometry in WalkthroughSettings"
+```
+
+---
+
+## Task 2: Add pure `clampPopupSize` helper
+
+**Files:**
+- Modify: `src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupPlacement.kt`
+- Create: `src/test/kotlin/com/forketyfork/walkthrough/WalkthroughPopupPlacementTest.kt`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/test/kotlin/com/forketyfork/walkthrough/WalkthroughPopupPlacementTest.kt`:
+
+```kotlin
+package com.forketyfork.walkthrough
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.awt.Dimension
+
+class WalkthroughPopupPlacementTest {
+
+    private val minWidth = WalkthroughPopupLayout.MINIMUM_WIDTH_PX
+    private val minHeight = WalkthroughPopupLayout.MINIMUM_HEIGHT_PX
+
+    @Test
+    fun clampPopupSizePreservesSizeWithinBounds() {
+        val clamped = clampPopupSize(Dimension(720, 480), maxWidth = 1200, maxHeight = 900)
+
+        assertEquals(Dimension(720, 480), clamped)
+    }
+
+    @Test
+    fun clampPopupSizeRaisesBelowMinimumToMinimum() {
+        val clamped = clampPopupSize(
+            Dimension(minWidth - 50, minHeight - 50),
+            maxWidth = 1200,
+            maxHeight = 900
+        )
+
+        assertEquals(Dimension(minWidth, minHeight), clamped)
+    }
+
+    @Test
+    fun clampPopupSizeLowersAboveMaximumToMaximum() {
+        val clamped = clampPopupSize(Dimension(2000, 1500), maxWidth = 1200, maxHeight = 900)
+
+        assertEquals(Dimension(1200, 900), clamped)
+    }
+
+    @Test
+    fun clampPopupSizeUsesMinimumWhenMaxIsBelowMinimum() {
+        val clamped = clampPopupSize(
+            Dimension(800, 500),
+            maxWidth = minWidth - 100,
+            maxHeight = minHeight - 100
+        )
+
+        assertEquals(Dimension(minWidth, minHeight), clamped)
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run:
+```bash
+./gradlew test --tests com.forketyfork.walkthrough.WalkthroughPopupPlacementTest
+```
+
+Expected: compilation failure — `clampPopupSize` is not defined.
+
+- [ ] **Step 3: Implement `clampPopupSize`**
+
+Append to `src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupPlacement.kt` (after the existing `constrainPopupScreenLocation` function):
+
+```kotlin
+internal fun clampPopupSize(size: Dimension, maxWidth: Int, maxHeight: Int): Dimension {
+    val minWidth = WalkthroughPopupLayout.MINIMUM_WIDTH_PX
+    val minHeight = WalkthroughPopupLayout.MINIMUM_HEIGHT_PX
+    val effectiveMaxWidth = maxWidth.coerceAtLeast(minWidth)
+    val effectiveMaxHeight = maxHeight.coerceAtLeast(minHeight)
+    return Dimension(
+        size.width.coerceIn(minWidth, effectiveMaxWidth),
+        size.height.coerceIn(minHeight, effectiveMaxHeight)
+    )
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run:
+```bash
+./gradlew test --tests com.forketyfork.walkthrough.WalkthroughPopupPlacementTest
+```
+
+Expected: all 4 tests pass.
+
+- [ ] **Step 5: Run lint and build**
+
+Run:
+```bash
+just lint && just build
+```
+
+Expected: both succeed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupPlacement.kt \
+        src/test/kotlin/com/forketyfork/walkthrough/WalkthroughPopupPlacementTest.kt
+git commit -m "feat: add clampPopupSize pure helper"
+```
+
+---
+
+## Task 3: Wire persistence into orchestrator and interaction handler
+
+This task replaces the in-memory `userMovedPopup` machinery with the
+persistence-driven pipeline. The interaction handler's callback contract
+changes to fire once on `mouseReleased`, and the orchestrator gains a unified
+`applyPopupGeometryForItem` used for both the initial show and every
+Next/Previous navigation.
+
+**Files:**
+- Modify: `src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupPlacement.kt`
+- Modify: `src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupInteraction.kt`
+- Modify: `src/main/kotlin/com/forketyfork/walkthrough/WalkthroughOrchestrator.kt`
+
+- [ ] **Step 1: Drop the `onLocationChanged` parameter from `movePopupBy`**
+
+In `src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupPlacement.kt`, replace `movePopupBy` with:
+
+```kotlin
+internal fun movePopupBy(
+    popup: WalkthroughPopupSurface,
+    editor: Editor,
+    deltaX: Float,
+    deltaY: Float
+) {
+    val currentLocation = popup.popupLocationOnScreen() ?: return
+    val popupSize = resolvePopupSize(popup) ?: WalkthroughPopupLayout.fallbackSize
+    val movedPoint = Point(
+        currentLocation.x + deltaX.roundToInt(),
+        currentLocation.y + deltaY.roundToInt()
+    )
+    popup.setPopupScreenLocation(constrainPopupScreenLocation(editor, movedPoint, popupSize))
+}
+```
+
+The connector repaint is already triggered by `setPopupScreenLocation` itself
+(it calls `repaint()` on the surface), so no external callback is needed.
+
+- [ ] **Step 2: Update `WalkthroughPopupInteraction.kt`**
+
+Replace the entire file `src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupInteraction.kt` with:
+
+```kotlin
+package com.forketyfork.walkthrough
+
+import com.intellij.openapi.editor.Editor
+import java.awt.Color as AwtColor
+import java.awt.Component
+import java.awt.Container
+import java.awt.Cursor
+import java.awt.Point
+import java.awt.event.ContainerAdapter
+import java.awt.event.ContainerEvent
+import java.awt.event.MouseAdapter
+import java.awt.event.MouseEvent
+import javax.swing.JComponent
+import javax.swing.JLayeredPane
+import javax.swing.JRootPane
+import javax.swing.SwingUtilities
+
+private const val DRAG_HANDLE_HEIGHT_PX = 64
+private const val CLOSE_BUTTON_HIT_BOX_PX = 60
+private const val RESIZE_HANDLE_SIZE_PX = 26
+private const val INTERACTION_LISTENER_CLIENT_PROPERTY = "walkthrough.popup.interaction.listener"
+private const val INTERACTION_CONTAINER_LISTENER_CLIENT_PROPERTY =
+    "walkthrough.popup.interaction.container.listener"
+
+private enum class PopupInteractionMode {
+    Drag,
+    Resize
+}
+
+internal fun makeComponentHierarchyTransparent(component: Component?) {
+    var current = component
+    while (current is JComponent) {
+        if (current is JRootPane || current is JLayeredPane) {
+            break
+        }
+        current.isOpaque = false
+        @Suppress("UseJBColor") // Fully transparent, theme-independent
+        current.background = AwtColor(0, 0, 0, 0)
+        current = current.parent
+    }
+}
+
+internal fun installPopupInteractionHandler(
+    panel: JComponent,
+    popupProvider: () -> WalkthroughPopupSurface?,
+    editorProvider: () -> Editor,
+    onInteractionEnd: () -> Unit
+) {
+    var lastScreenPoint: Point? = null
+    var interactionMode: PopupInteractionMode? = null
+
+    val interactionListener = object : MouseAdapter() {
+        override fun mousePressed(event: MouseEvent) {
+            if (event.button != MouseEvent.BUTTON1) {
+                interactionMode = null
+                lastScreenPoint = null
+                return
+            }
+            interactionMode = when {
+                isWithinResizeHandle(panel, event.component, event.point) -> PopupInteractionMode.Resize
+                isWithinDragHandle(panel, event.component, event.point) -> PopupInteractionMode.Drag
+                else -> null
+            }
+            lastScreenPoint = interactionMode?.let { event.locationOnScreen }
+        }
+
+        override fun mouseDragged(event: MouseEvent) {
+            val mode = interactionMode ?: return
+            val popup = popupProvider() ?: return
+            val previousScreenPoint = lastScreenPoint ?: event.locationOnScreen
+            val currentScreenPoint = event.locationOnScreen
+            when (mode) {
+                PopupInteractionMode.Drag -> movePopupBy(
+                    popup = popup,
+                    editor = editorProvider(),
+                    deltaX = (currentScreenPoint.x - previousScreenPoint.x).toFloat(),
+                    deltaY = (currentScreenPoint.y - previousScreenPoint.y).toFloat()
+                )
+
+                PopupInteractionMode.Resize -> resizePopupBy(
+                    popup = popup,
+                    panel = panel,
+                    editor = editorProvider(),
+                    deltaX = (currentScreenPoint.x - previousScreenPoint.x).toFloat(),
+                    deltaY = (currentScreenPoint.y - previousScreenPoint.y).toFloat()
+                )
+            }
+            lastScreenPoint = currentScreenPoint
+        }
+
+        override fun mouseMoved(event: MouseEvent) {
+            updateInteractionCursor(panel, event.component, event.point)
+        }
+
+        override fun mouseReleased(event: MouseEvent) {
+            val hadInteraction = interactionMode != null
+            interactionMode = null
+            lastScreenPoint = null
+            updateInteractionCursor(panel, event.component, event.point)
+            if (hadInteraction) {
+                onInteractionEnd()
+            }
+        }
+
+        override fun mouseExited(event: MouseEvent) {
+            if (interactionMode == null) {
+                event.component.cursor = Cursor.getDefaultCursor()
+                panel.cursor = Cursor.getDefaultCursor()
+            }
+        }
+    }
+
+    attachMouseListenersRecursively(panel, interactionListener)
+}
+
+private fun attachMouseListenersRecursively(component: Component, listener: MouseAdapter) {
+    if (component is JComponent) {
+        if (component.getClientProperty(
+                INTERACTION_LISTENER_CLIENT_PROPERTY
+            ) !== listener
+        ) {
+            component.addMouseListener(listener)
+            component.addMouseMotionListener(listener)
+            component.putClientProperty(INTERACTION_LISTENER_CLIENT_PROPERTY, listener)
+        }
+    } else {
+        component.addMouseListener(listener)
+        component.addMouseMotionListener(listener)
+    }
+    if (component is Container) {
+        component.components.forEach { child ->
+            attachMouseListenersRecursively(child, listener)
+        }
+        if (component is JComponent &&
+            component.getClientProperty(INTERACTION_CONTAINER_LISTENER_CLIENT_PROPERTY) == null
+        ) {
+            val containerListener = object : ContainerAdapter() {
+                override fun componentAdded(event: ContainerEvent) {
+                    attachMouseListenersRecursively(event.child, listener)
+                }
+            }
+            component.addContainerListener(containerListener)
+            component.putClientProperty(INTERACTION_CONTAINER_LISTENER_CLIENT_PROPERTY, containerListener)
+        }
+    }
+}
+
+private fun updateInteractionCursor(panel: JComponent, component: Component, point: Point) {
+    val cursor = when {
+        isWithinResizeHandle(panel, component, point) ->
+            Cursor.getPredefinedCursor(Cursor.SE_RESIZE_CURSOR)
+
+        isWithinDragHandle(panel, component, point) ->
+            Cursor.getPredefinedCursor(Cursor.MOVE_CURSOR)
+
+        else -> Cursor.getDefaultCursor()
+    }
+    component.cursor = cursor
+    panel.cursor = cursor
+}
+
+private fun isWithinDragHandle(panel: JComponent, component: Component, point: Point): Boolean {
+    val pointInPanel = SwingUtilities.convertPoint(component, point, panel)
+    return pointInPanel.y <= DRAG_HANDLE_HEIGHT_PX &&
+        pointInPanel.x <= panel.width - CLOSE_BUTTON_HIT_BOX_PX
+}
+
+private fun isWithinResizeHandle(panel: JComponent, component: Component, point: Point): Boolean {
+    val pointInPanel = SwingUtilities.convertPoint(component, point, panel)
+    return pointInPanel.x >= panel.width - RESIZE_HANDLE_SIZE_PX &&
+        pointInPanel.y >= panel.height - RESIZE_HANDLE_SIZE_PX
+}
+
+private fun resizePopupBy(
+    popup: WalkthroughPopupSurface,
+    panel: JComponent,
+    editor: Editor,
+    deltaX: Float,
+    deltaY: Float
+) {
+    val currentLocation = popup.popupLocationOnScreen() ?: return
+    val currentSize = resolvePopupSize(popup)
+        ?: panel.preferredSize
+        ?: WalkthroughPopupLayout.fallbackSize
+    val rootPane = SwingUtilities.getRootPane(editor.contentComponent)
+    val maxWidth = rootPane?.let { pane ->
+        val rootLocation = Point(0, 0).also { SwingUtilities.convertPointToScreen(it, pane) }
+        (
+            rootLocation.x + pane.width - currentLocation.x - WalkthroughPopupLayout.VIEWPORT_PADDING
+            ).coerceAtLeast(WalkthroughPopupLayout.MINIMUM_WIDTH_PX)
+    } ?: Int.MAX_VALUE
+    val maxHeight = rootPane?.let { pane ->
+        val rootLocation = Point(0, 0).also { SwingUtilities.convertPointToScreen(it, pane) }
+        (
+            rootLocation.y + pane.height - currentLocation.y - WalkthroughPopupLayout.VIEWPORT_PADDING
+            ).coerceAtLeast(WalkthroughPopupLayout.MINIMUM_HEIGHT_PX)
+    } ?: Int.MAX_VALUE
+    val targetSize = java.awt.Dimension(
+        (currentSize.width + deltaX.toInt()).coerceIn(WalkthroughPopupLayout.MINIMUM_WIDTH_PX, maxWidth),
+        (currentSize.height + deltaY.toInt()).coerceIn(WalkthroughPopupLayout.MINIMUM_HEIGHT_PX, maxHeight)
+    )
+
+    panel.preferredSize = targetSize
+    panel.revalidate()
+    popup.popupSize = targetSize
+    popup.moveToFitScreen(editor)
+}
+```
+
+Three changes vs. the current file: the parameter on `installPopupInteractionHandler` is renamed `onPopupMoved` → `onInteractionEnd`; the per-motion callback is dropped from `movePopupBy` / `resizePopupBy` calls inside `mouseDragged`; `mouseReleased` now fires `onInteractionEnd()` when an interaction was in progress.
+
+- [ ] **Step 3: Rewrite the orchestrator to use the persistence pipeline**
+
+Replace the entire file `src/main/kotlin/com/forketyfork/walkthrough/WalkthroughOrchestrator.kt` with:
+
+```kotlin
+package com.forketyfork.walkthrough
+
+import androidx.compose.runtime.mutableStateOf
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.fileEditor.FileEditorManagerEvent
+import com.intellij.openapi.fileEditor.FileEditorManagerListener
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Disposer
+import org.jetbrains.jewel.bridge.JewelComposePanel
+import java.awt.Color as AwtColor
+import java.awt.Dimension
+import java.awt.Point
+import javax.swing.JComponent
+import javax.swing.SwingUtilities
+
+fun showWalkthroughItems(project: Project, items: List<WalkthroughItem>): Boolean =
+    showWalkthroughSession(project, items, acceptsQuestions = false) != null
+
+fun showWalkthroughItems(project: Project, editor: Editor, items: List<WalkthroughItem>): Boolean =
+    showWalkthroughSession(project, editor, items, acceptsQuestions = false) != null
+
+fun showWalkthroughSession(
+    project: Project,
+    items: List<WalkthroughItem>,
+    acceptsQuestions: Boolean
+): WalkthroughSession? {
+    val fallbackEditor = FileEditorManager.getInstance(project).selectedTextEditor
+    val target = items.firstOrNull()
+        ?.let { item -> resolveWalkthroughTarget(project, fallbackEditor, item) }
+    return target?.let { resolved -> showWalkthroughSession(project, resolved.editor, items, acceptsQuestions) }
+}
+
+@Suppress("LongMethod")
+fun showWalkthroughSession(
+    project: Project,
+    editor: Editor,
+    items: List<WalkthroughItem>,
+    acceptsQuestions: Boolean
+): WalkthroughSession? {
+    val firstTarget = items.firstOrNull()
+        ?.let { item -> resolveWalkthroughTarget(project, editor, item) }
+        ?: return null
+    val paletteState = mutableStateOf(WalkthroughSettings.getInstance().selectedPalette)
+    val sessionDisposable = Disposer.newCheckedDisposable("WalkthroughPopupSession")
+    Disposer.register(project, sessionDisposable)
+
+    val registry = WalkthroughSessionRegistry.getInstance(project)
+    registry.swapActive(sessionDisposable)?.let(Disposer::dispose)
+    val session = registry.create(items, acceptsQuestions)
+    Disposer.register(
+        sessionDisposable,
+        object : Disposable {
+            override fun dispose() {
+                registry.remove(session.id)
+                registry.clearActive(sessionDisposable)
+            }
+        }
+    )
+
+    var popupRef: WalkthroughPopupSurface? = null
+    var currentEditor = firstTarget.editor
+    var pendingNavigationId = 0
+
+    fun repaintPopup() {
+        popupRef?.let { popup ->
+            popup.refreshBounds()
+            popup.repaint()
+        }
+    }
+
+    fun updatePopupPalette(palette: WalkthroughPalette) {
+        SwingUtilities.invokeLater {
+            if (sessionDisposable.isDisposed) {
+                return@invokeLater
+            }
+            paletteState.value = palette
+            popupRef?.updatePalette(palette)
+        }
+    }
+
+    fun showItem(item: WalkthroughItem) {
+        val popup = popupRef ?: return
+        val target = resolveWalkthroughTarget(project, currentEditor, item) ?: return
+        currentEditor = target.editor
+        popup.update(currentEditor, target.popupItem)
+        popup.connectorHidden = false
+        applyPopupGeometryForItem(popup, currentEditor, target.popupItem)
+    }
+
+    fun scheduleItemNavigation(item: WalkthroughItem) {
+        pendingNavigationId += 1
+        val navigationId = pendingNavigationId
+        SwingUtilities.invokeLater {
+            if (sessionDisposable.isDisposed || navigationId != pendingNavigationId) {
+                return@invokeLater
+            }
+            showItem(item)
+        }
+    }
+
+    val panel = createWalkthroughPanel(
+        project = project,
+        session = session,
+        paletteProvider = { paletteState.value },
+        onItemDisplayed = ::scheduleItemNavigation,
+        onNavigateToSource = ::scheduleItemNavigation,
+        onClose = { popupRef?.cancel() }
+    )
+    makeComponentHierarchyTransparent(panel)
+
+    installPopupInteractionHandler(
+        panel = panel,
+        popupProvider = { popupRef },
+        editorProvider = { currentEditor },
+        onInteractionEnd = { saveCurrentGeometry(popupRef) }
+    )
+
+    project.messageBus.connect(sessionDisposable).subscribe(
+        FileEditorManagerListener.FILE_EDITOR_MANAGER,
+        object : FileEditorManagerListener {
+            override fun selectionChanged(event: FileEditorManagerEvent) {
+                val selectedEditor = FileEditorManager.getInstance(project).selectedTextEditor
+                popupRef?.connectorHidden = selectedEditor?.document !== currentEditor.document
+            }
+        }
+    )
+    ApplicationManager.getApplication().messageBus.connect(sessionDisposable).subscribe(
+        WalkthroughSettingsListener.TOPIC,
+        object : WalkthroughSettingsListener {
+            override fun paletteChanged(palette: WalkthroughPalette) {
+                updatePopupPalette(palette)
+            }
+        }
+    )
+
+    val popup = WalkthroughPopupSurface(
+        content = panel,
+        palette = paletteState.value,
+        onCloseRequested = {
+            popupRef = null
+            registry.remove(session.id)
+            Disposer.dispose(sessionDisposable)
+        }
+    )
+    popupRef = popup
+    Disposer.register(sessionDisposable, popup)
+    popup.update(currentEditor, firstTarget.popupItem)
+    applyPopupGeometryForItem(popup, currentEditor, firstTarget.popupItem)
+    repaintPopup()
+    return session
+}
+
+private fun saveCurrentGeometry(popup: WalkthroughPopupSurface?) {
+    popup ?: return
+    val location = popup.popupLocationOnScreen() ?: return
+    val size = resolvePopupSize(popup) ?: return
+    WalkthroughSettings.getInstance().saveGeometry(
+        PopupGeometry(location.x, location.y, size.width, size.height)
+    )
+}
+
+private fun applyPopupGeometryForItem(
+    popup: WalkthroughPopupSurface,
+    editor: Editor,
+    item: WalkthroughItem
+) {
+    val settings = WalkthroughSettings.getInstance()
+    val persisted = settings.loadGeometry()
+
+    if (persisted == null) {
+        movePopupNearItem(popup, editor, item)
+    } else {
+        val rootPane = SwingUtilities.getRootPane(editor.contentComponent)
+        val maxWidth = rootPane?.let { it.width - 2 * WalkthroughPopupLayout.VIEWPORT_PADDING }
+            ?: Int.MAX_VALUE
+        val maxHeight = rootPane?.let { it.height - 2 * WalkthroughPopupLayout.VIEWPORT_PADDING }
+            ?: Int.MAX_VALUE
+        val clampedSize = clampPopupSize(
+            Dimension(persisted.width, persisted.height),
+            maxWidth = maxWidth,
+            maxHeight = maxHeight
+        )
+        popup.popupSize = clampedSize
+        val avoided = avoidLineOverlap(Point(persisted.x, persisted.y), clampedSize, editor, item.line)
+        val constrained = constrainPopupScreenLocation(editor, avoided, clampedSize)
+        val reAvoided = avoidLineOverlap(constrained, clampedSize, editor, item.line)
+        val finalPoint = constrainPopupScreenLocation(editor, reAvoided, clampedSize)
+        popup.show(editor, finalPoint)
+    }
+
+    val finalLocation = popup.popupLocationOnScreen() ?: return
+    val finalSize = resolvePopupSize(popup) ?: return
+    val finalGeometry = PopupGeometry(finalLocation.x, finalLocation.y, finalSize.width, finalSize.height)
+    if (persisted != finalGeometry) {
+        settings.saveGeometry(finalGeometry)
+    }
+}
+
+private fun createWalkthroughPanel(
+    project: Project,
+    session: WalkthroughSession,
+    paletteProvider: () -> WalkthroughPalette,
+    onItemDisplayed: (WalkthroughItem) -> Unit,
+    onNavigateToSource: (WalkthroughItem) -> Unit,
+    onClose: () -> Unit
+): JComponent =
+    JewelComposePanel {
+        WalkthroughItemContent(
+            project = project,
+            session = session,
+            palette = paletteProvider(),
+            onItemDisplayed = onItemDisplayed,
+            onNavigateToSource = onNavigateToSource,
+            onClose = onClose
+        )
+    }.apply {
+        isOpaque = false
+        @Suppress("UseJBColor")
+        background = AwtColor(0, 0, 0, 0)
+        minimumSize = Dimension(
+            WalkthroughPopupLayout.MINIMUM_WIDTH_PX,
+            WalkthroughPopupLayout.MINIMUM_HEIGHT_PX
+        )
+        preferredSize = WalkthroughPopupLayout.fallbackSize
+    }
+```
+
+Notable diffs versus the current file:
+- `var userMovedPopup`, `fun onPopupUserMoved()`, and the file-level
+  `repositionPopupForItem` helper introduced in the prior commit are removed.
+- A new file-level `saveCurrentGeometry(popup)` helper reads the current popup
+  rectangle and writes through `WalkthroughSettings.saveGeometry(...)`. Kept
+  at file scope (not as an inner function) so its `?: return` branches do not
+  inflate the cyclomatic complexity of `showWalkthroughSession`.
+- A new file-level `applyPopupGeometryForItem` function implements the
+  unified pipeline (load → clamp size → avoid overlap → constrain → apply →
+  persist back when changed).
+- `showItem` and the initial-show block both call `applyPopupGeometryForItem`
+  instead of branching on `userMovedPopup`.
+- `installPopupInteractionHandler` is now wired with
+  `onInteractionEnd = { saveCurrentGeometry(popupRef) }`.
+- A `repaintPopup()` is added after the initial `applyPopupGeometryForItem`
+  call to ensure the connector renders against the final bounds (the
+  `popup.refreshBounds()` it triggers also picks up the layered pane).
+- Adds a missing `import java.awt.Point` for the new pipeline.
+
+- [ ] **Step 4: Verify the project still builds**
+
+Run:
+```bash
+just build
+```
+
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 5: Verify lint still passes**
+
+Run:
+```bash
+just lint
+```
+
+Expected: BUILD SUCCESSFUL (detekt clean).
+
+- [ ] **Step 6: Run the full test suite**
+
+Run:
+```bash
+just test
+```
+
+Expected: all tests pass, including the new ones from Tasks 1 and 2.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupPlacement.kt \
+        src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupInteraction.kt \
+        src/main/kotlin/com/forketyfork/walkthrough/WalkthroughOrchestrator.kt
+git commit -m "feat: apply persisted popup geometry across walkthrough sessions"
+```
+
+---
+
+## Task 4: Manual verification in a sandboxed IDE
+
+The unit tests cover the persistence layer and the pure size-clamp helper. The
+integration with Swing/Editor must be validated in `runIde`.
+
+**Files:** none — this task only runs the IDE and exercises the popup.
+
+- [ ] **Step 1: Launch the sandboxed IDE**
+
+Run:
+```bash
+just run
+```
+
+Expected: a sandbox IntelliJ instance opens.
+
+- [ ] **Step 2: Verify drag persistence within a session**
+
+Open any project in the sandbox, trigger a walkthrough via the existing UI or
+MCP tooling, drag the popup to a new location, then click Next. The popup
+should stay where you dragged it (only nudging aside if it overlaps the new
+target line).
+
+- [ ] **Step 3: Verify drag persistence across sessions in the same project**
+
+Close the walkthrough, start another walkthrough in the same project. The
+popup should re-appear at the last dragged position.
+
+- [ ] **Step 4: Verify drag persistence across projects**
+
+Open a different project in the sandbox. Start a walkthrough. The popup
+should re-appear at the same dragged position (application-wide setting).
+
+- [ ] **Step 5: Verify overlap avoidance**
+
+Drag the popup directly over a future target line, then click Next. The popup
+should nudge above or below the target line.
+
+- [ ] **Step 6: Verify resize persistence**
+
+Resize the popup via the bottom-right resize handle, close the walkthrough,
+start another. The popup should re-appear at the new size.
+
+- [ ] **Step 7: Verify restart persistence**
+
+Close the sandbox IDE entirely. Run `just run` again. Start a walkthrough.
+The popup should re-appear at the last dragged position and size.
+
+- [ ] **Step 8: Update the PR description on success**
+
+If all manual checks pass, the PR description for #24 already covers the
+broader fix. Optionally, append a short note that the position is now
+remembered application-wide, including across IDE restarts.
+
+```bash
+gh pr view 24 --json body --jq .body
+# Edit and update via `gh pr edit 24 --body "..."` as needed.
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage check:**
+  - Application-wide scope via extension of `WalkthroughSettings` → Task 1.
+  - `PopupGeometry` data class with sentinel-based `loadGeometry()` and
+    idempotent `saveGeometry()` → Task 1.
+  - Pure size-clamping helper → Task 2.
+  - Removal of `userMovedPopup`, unified `applyPopupGeometryForItem` pipeline
+    (load → clamp size → avoid overlap → constrain → apply → persist when
+    changed) → Task 3.
+  - Save fires once on `mouseReleased` when an interaction was in progress;
+    per-motion callback is dropped → Task 3.
+  - Manual coverage of the spec's behavioral test plan (across sessions,
+    projects, restart, overlap, resize) → Task 4.
+- **Placeholder scan:** none — every step contains the actual code or command.
+- **Type consistency:** `PopupGeometry`, `loadGeometry()`, `saveGeometry()`,
+  `clampPopupSize()`, `applyPopupGeometryForItem()`, and
+  `onInteractionEnd` are spelled the same way across all tasks.

--- a/docs/superpowers/plans/2026-05-18-popup-geometry-persistence.md
+++ b/docs/superpowers/plans/2026-05-18-popup-geometry-persistence.md
@@ -15,6 +15,7 @@
 ## Task 1: Extend `WalkthroughSettings` with `PopupGeometry`
 
 **Files:**
+
 - Modify: `src/main/kotlin/com/forketyfork/walkthrough/WalkthroughSettings.kt`
 - Create: `src/test/kotlin/com/forketyfork/walkthrough/WalkthroughSettingsGeometryTest.kt`
 
@@ -90,6 +91,7 @@ class WalkthroughSettingsGeometryTest {
 - [ ] **Step 2: Run the tests to verify they fail**
 
 Run:
+
 ```bash
 ./gradlew test --tests com.forketyfork.walkthrough.WalkthroughSettingsGeometryTest
 ```
@@ -193,6 +195,7 @@ Note the change to `state`: it is now exposed as `internal var ... private set` 
 - [ ] **Step 4: Run the tests to verify they pass**
 
 Run:
+
 ```bash
 ./gradlew test --tests com.forketyfork.walkthrough.WalkthroughSettingsGeometryTest
 ```
@@ -202,6 +205,7 @@ Expected: all 5 tests pass.
 - [ ] **Step 5: Run lint and build**
 
 Run:
+
 ```bash
 just lint && just build
 ```
@@ -221,6 +225,7 @@ git commit -m "feat: persist popup geometry in WalkthroughSettings"
 ## Task 2: Add pure `clampPopupSize` helper
 
 **Files:**
+
 - Modify: `src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupPlacement.kt`
 - Create: `src/test/kotlin/com/forketyfork/walkthrough/WalkthroughPopupPlacementTest.kt`
 
@@ -281,6 +286,7 @@ class WalkthroughPopupPlacementTest {
 - [ ] **Step 2: Run the tests to verify they fail**
 
 Run:
+
 ```bash
 ./gradlew test --tests com.forketyfork.walkthrough.WalkthroughPopupPlacementTest
 ```
@@ -307,6 +313,7 @@ internal fun clampPopupSize(size: Dimension, maxWidth: Int, maxHeight: Int): Dim
 - [ ] **Step 4: Run the tests to verify they pass**
 
 Run:
+
 ```bash
 ./gradlew test --tests com.forketyfork.walkthrough.WalkthroughPopupPlacementTest
 ```
@@ -316,6 +323,7 @@ Expected: all 4 tests pass.
 - [ ] **Step 5: Run lint and build**
 
 Run:
+
 ```bash
 just lint && just build
 ```
@@ -341,6 +349,7 @@ changes to fire once on `mouseReleased`, and the orchestrator gains a unified
 Next/Previous navigation.
 
 **Files:**
+
 - Modify: `src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupPlacement.kt`
 - Modify: `src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupInteraction.kt`
 - Modify: `src/main/kotlin/com/forketyfork/walkthrough/WalkthroughOrchestrator.kt`
@@ -821,6 +830,7 @@ private fun createWalkthroughPanel(
 ```
 
 Notable diffs versus the current file:
+
 - `var userMovedPopup`, `fun onPopupUserMoved()`, and the file-level
   `repositionPopupForItem` helper introduced in the prior commit are removed.
 - A new file-level `saveCurrentGeometry(popup)` helper reads the current popup
@@ -842,6 +852,7 @@ Notable diffs versus the current file:
 - [ ] **Step 4: Verify the project still builds**
 
 Run:
+
 ```bash
 just build
 ```
@@ -851,6 +862,7 @@ Expected: BUILD SUCCESSFUL.
 - [ ] **Step 5: Verify lint still passes**
 
 Run:
+
 ```bash
 just lint
 ```
@@ -860,6 +872,7 @@ Expected: BUILD SUCCESSFUL (detekt clean).
 - [ ] **Step 6: Run the full test suite**
 
 Run:
+
 ```bash
 just test
 ```
@@ -887,6 +900,7 @@ integration with Swing/Editor must be validated in `runIde`.
 - [ ] **Step 1: Launch the sandboxed IDE**
 
 Run:
+
 ```bash
 just run
 ```

--- a/docs/superpowers/specs/2026-05-18-popup-geometry-persistence-design.md
+++ b/docs/superpowers/specs/2026-05-18-popup-geometry-persistence-design.md
@@ -36,7 +36,7 @@ The plugin already has two relevant pieces:
 | First-time fallback            | Existing `movePopupNearItem` placement                  |
 | Behavior on Next within session| Same as first show: load → avoid overlap → constrain    |
 | Replacement of `userMovedPopup`| Yes — the in-memory flag is removed                     |
-| Persistence triggers           | On every drag/resize mouse-motion event, and on initial show when the position is adjusted from what was loaded |
+| Persistence triggers           | Once on mouse release after a drag or resize, and once on initial show when the position is adjusted from what was loaded |
 
 ## Architecture
 
@@ -87,20 +87,28 @@ without Swing.
 
 The orchestrator already wires a `onPopupMoved` callback through
 `installPopupInteractionHandler`. The recent commit repurposed it to flip
-`userMovedPopup`; this design replaces that with a save:
+`userMovedPopup`; this design replaces that with a save fired only when the
+interaction completes:
 
-- Rename `onPopupMoved` → `onGeometryChanged` in `WalkthroughPopupInteraction`
-  (now covers resize too, not just move).
+- Rename `onPopupMoved` → `onInteractionEnd` in `WalkthroughPopupInteraction`.
+- Stop invoking the callback from inside `movePopupBy` / `resizePopupBy`. Drop
+  the `onLocationChanged` parameter from both helpers — per-motion redraws are
+  already handled by `setPopupScreenLocation` (which calls `repaint()` on the
+  surface) and the `popupSize` setter (which also calls `repaint()`), so no
+  external trigger is needed for the connector to follow the popup during a
+  drag.
+- Fire `onInteractionEnd()` from `mouseReleased`, but only when
+  `interactionMode != null` (i.e. the press began on the drag handle or resize
+  handle). This avoids firing on stray clicks elsewhere on the popup.
 - Signature stays `() -> Unit`. Inside the callback the orchestrator queries
   `popup.popupLocationOnScreen()` and `resolvePopupSize(popup)` and calls
   `geometryService.saveGeometry(x, y, w, h)`. Keeping the interaction module
   ignorant of the geometry service preserves the existing module boundary.
 
-Both `movePopupBy` (drag) and `resizePopupBy` (resize) already call the
-callback after applying their delta. Note that the callback fires on every
-`mouseDragged` event, not just on release, so saves are frequent during a
-drag — but the underlying `PersistentStateComponent` holds state in memory and
-the IDE flushes to disk asynchronously, so the cost is negligible.
+The result: exactly one save per completed drag and one per completed resize,
+regardless of how many `mouseDragged` events fired between press and release.
+A press-release with no motion still triggers one save, which is a harmless
+no-op because the persisted geometry is unchanged.
 
 ### Files touched
 

--- a/docs/superpowers/specs/2026-05-18-popup-geometry-persistence-design.md
+++ b/docs/superpowers/specs/2026-05-18-popup-geometry-persistence-design.md
@@ -29,14 +29,14 @@ place.
 
 ## Decisions
 
-| Decision                       | Choice                                                  |
-| ------------------------------ | ------------------------------------------------------- |
-| Scope                          | Application-wide (extend existing `WalkthroughSettings`) |
-| Coordinate system              | Absolute screen coordinates                             |
-| First-time fallback            | Existing `movePopupNearItem` placement                  |
-| Behavior on Next within session| Same as first show: load → avoid overlap → constrain    |
-| Replacement of `userMovedPopup`| Yes — the in-memory flag is removed                     |
-| Persistence triggers           | Once on mouse release after a drag or resize, and once on initial show when the position is adjusted from what was loaded |
+- **Scope:** application-wide (extend existing `WalkthroughSettings`).
+- **Coordinate system:** absolute screen coordinates.
+- **First-time fallback:** existing `movePopupNearItem` placement.
+- **Behavior on Next within session:** same as first show — load, avoid
+  overlap, constrain.
+- **Replacement of `userMovedPopup`:** yes; the in-memory flag is removed.
+- **Persistence triggers:** once on mouse release after a drag or resize, and
+  once on initial show when the position is adjusted from what was loaded.
 
 ## Architecture
 
@@ -121,12 +121,18 @@ no-op because the persisted geometry is unchanged.
 
 ### Files touched
 
-| File                             | Change                                                                                                                              |
-| -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `WalkthroughSettings.kt`         | Add `popupX/Y/Width/Height` fields to `State`; add `PopupGeometry` data class; add `loadGeometry()` and `saveGeometry()` methods.  |
-| `WalkthroughOrchestrator.kt`     | Remove `userMovedPopup` and `onPopupUserMoved`. Replace `repositionPopupForItem` with `applyPopupGeometryForItem`. Wire save hook. |
-| `WalkthroughPopupPlacement.kt`   | Add a helper that takes a starting `Rectangle`, target line, editor, and returns the constrained, overlap-avoided rectangle.        |
-| `WalkthroughPopupInteraction.kt` | Rename `onPopupMoved` → `onInteractionEnd`; drop `onLocationChanged` param from `movePopupBy` / `resizePopupBy`; fire callback from `mouseReleased`. |
+- **`WalkthroughSettings.kt`** — add `popupX/Y/Width/Height` fields to `State`;
+  add a `PopupGeometry` data class; add `loadGeometry()` and `saveGeometry()`
+  methods.
+- **`WalkthroughOrchestrator.kt`** — remove `userMovedPopup` and
+  `onPopupUserMoved`. Replace `repositionPopupForItem` with
+  `applyPopupGeometryForItem`. Wire the save hook.
+- **`WalkthroughPopupPlacement.kt`** — add a helper that takes a starting
+  `Rectangle`, target line, and editor, and returns the constrained,
+  overlap-avoided rectangle.
+- **`WalkthroughPopupInteraction.kt`** — rename `onPopupMoved` →
+  `onInteractionEnd`; drop the `onLocationChanged` param from `movePopupBy` /
+  `resizePopupBy`; fire the callback from `mouseReleased`.
 
 No `plugin.xml` change is required — `WalkthroughSettings` is already
 registered as an `applicationService`.

--- a/docs/superpowers/specs/2026-05-18-popup-geometry-persistence-design.md
+++ b/docs/superpowers/specs/2026-05-18-popup-geometry-persistence-design.md
@@ -1,0 +1,151 @@
+# Walkthrough Popup Geometry Persistence
+
+## Goal
+
+Persist the walkthrough popup's position and size in project-scoped settings so
+the popup re-appears in the same place across walkthrough sessions (and across
+IDE restarts), not just across Next/Previous clicks within a single session. On
+every show, apply the persisted geometry and then nudge the popup out of the way
+if it would overlap the target line. Save the geometry on every drag and resize.
+
+## Background
+
+Today the popup geometry is computed at show time and lives only in the popup
+Swing component. A recent change (commit `6681cc7`) introduced an in-memory
+`userMovedPopup` flag so that, within a single walkthrough session, clicking
+Next does not snap the popup back next to the target line. That fix is correct
+in spirit but limited: it does not survive ending one walkthrough and starting
+another, and it does not survive an IDE restart. Issue
+[#23](https://github.com/forketyfork/walkthrough-plugin/issues/23) tracks the
+broader bug.
+
+The plugin already has two relevant pieces:
+
+- `WalkthroughSettings` — an application-level `PersistentStateComponent` for
+  the color palette. Wrong scope for popup geometry (per-application, not
+  per-project).
+- `WalkthroughHistoryService` — a project-level service that writes to
+  `.idea/walkthroughs/`. Correct pattern to mirror for project-scoped state.
+
+## Decisions
+
+| Decision                       | Choice                                                  |
+| ------------------------------ | ------------------------------------------------------- |
+| Scope                          | Per-project (under `.idea/`)                            |
+| Coordinate system              | Absolute screen coordinates                             |
+| First-time fallback            | Existing `movePopupNearItem` placement                  |
+| Behavior on Next within session| Same as first show: load → avoid overlap → constrain    |
+| Replacement of `userMovedPopup`| Yes — the in-memory flag is removed                     |
+| Persistence triggers           | On every drag/resize mouse-motion event, and on initial show when the position is adjusted from what was loaded |
+
+## Architecture
+
+### New component: `WalkthroughPopupGeometryService`
+
+Project-level `PersistentStateComponent` storing the most recently observed
+popup geometry.
+
+- Registered in `plugin.xml` as a `projectService`.
+- `@Storage("walkthroughPopup.xml")` → file lives under `.idea/walkthroughPopup.xml`.
+- State fields: `x: Int`, `y: Int`, `width: Int`, `height: Int`.
+- "Unset" sentinel: all four fields default to `Int.MIN_VALUE`. The service
+  exposes `loadGeometry(): PopupGeometry?` returning `null` when unset.
+- Mutation API: `saveGeometry(x, y, width, height)` updates state in place.
+  Writes are idempotent — saving the same geometry twice is a no-op.
+
+```kotlin
+internal data class PopupGeometry(val x: Int, val y: Int, val width: Int, val height: Int)
+```
+
+### Unified placement pipeline
+
+`WalkthroughOrchestrator` invokes a single `applyPopupGeometryForItem` function
+both on first show and on every Next/Previous navigation:
+
+1. **Load** persisted geometry from `WalkthroughPopupGeometryService`.
+2. **Choose starting rectangle:**
+   - If persisted geometry exists, use it.
+   - Else, fall back to `movePopupNearItem` (existing default placement).
+3. **Clamp size** to `[MINIMUM_WIDTH_PX, rootPaneWidth - 2 * VIEWPORT_PADDING]`
+   (and the height equivalent). This guards against a persisted size that no
+   longer fits on the current monitor / window.
+4. **Avoid overlap** with the target line by passing the candidate point
+   through the existing `avoidLineOverlap` helper.
+5. **Constrain** to the editor's root pane via the existing
+   `constrainPopupScreenLocation`.
+6. **Apply** the final rectangle to the popup.
+7. **Persist back** if the final geometry differs from the loaded geometry
+   (e.g., the overlap-avoid step shifted the popup, or the size was clamped).
+   This way the user does not see the popup jump on the next show.
+
+The function is pure with respect to the persistence service in this sense:
+given persisted geometry, target line, and root-pane bounds, it returns a
+deterministic final rectangle. That separation lets us unit-test the reducer
+without Swing.
+
+### Save hooks (drag and resize)
+
+The orchestrator already wires a `onPopupMoved` callback through
+`installPopupInteractionHandler`. The recent commit repurposed it to flip
+`userMovedPopup`; this design replaces that with a save:
+
+- Rename `onPopupMoved` → `onGeometryChanged` in `WalkthroughPopupInteraction`
+  (now covers resize too, not just move).
+- Signature stays `() -> Unit`. Inside the callback the orchestrator queries
+  `popup.popupLocationOnScreen()` and `resolvePopupSize(popup)` and calls
+  `geometryService.saveGeometry(x, y, w, h)`. Keeping the interaction module
+  ignorant of the geometry service preserves the existing module boundary.
+
+Both `movePopupBy` (drag) and `resizePopupBy` (resize) already call the
+callback after applying their delta. Note that the callback fires on every
+`mouseDragged` event, not just on release, so saves are frequent during a
+drag — but the underlying `PersistentStateComponent` holds state in memory and
+the IDE flushes to disk asynchronously, so the cost is negligible.
+
+### Files touched
+
+| File                                       | Change                                                                                                                              |
+| ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `WalkthroughPopupGeometryService.kt` (new) | `PersistentStateComponent` with load/save API and `PopupGeometry` data class.                                                       |
+| `META-INF/plugin.xml`                      | Register `<projectService>` for `WalkthroughPopupGeometryService`.                                                                  |
+| `WalkthroughOrchestrator.kt`               | Remove `userMovedPopup` and `onPopupUserMoved`. Replace `repositionPopupForItem` with `applyPopupGeometryForItem`. Wire save hook. |
+| `WalkthroughPopupPlacement.kt`             | Add a helper that takes a starting `Rectangle`, target line, editor, and returns the constrained, overlap-avoided rectangle.        |
+| `WalkthroughPopupInteraction.kt`           | Rename `onPopupMoved` → `onGeometryChanged`; pass screen rectangle to the callback.                                                 |
+
+## Edge cases
+
+- **No persisted geometry yet (first walkthrough in project):** fall back to
+  `movePopupNearItem`. The result is then persisted, so the second walkthrough
+  starts from the same spot.
+- **Persisted position is off-screen (monitor unplugged, IDE window moved):**
+  `constrainPopupScreenLocation` clamps the popup back inside the root pane.
+  The clamped rectangle is then persisted, so the next show is stable.
+- **Persisted size larger than current root pane:** clamped to the root-pane
+  width/height minus viewport padding. Clamped size is persisted.
+- **Persisted position overlaps the new target line:** `avoidLineOverlap`
+  shifts the popup above or below the line. Shifted position is persisted.
+- **Switching editors mid-walkthrough:** geometry is in screen coordinates, so
+  it applies the same way regardless of which editor's layered pane currently
+  hosts the popup.
+
+## Testing
+
+- **Unit (no Swing):** the new pure reducer
+  `applyPopupGeometryForItem(starting, line, editor, rootPaneBounds) →
+  finalRect` is testable. Cover: (a) persisted-and-fine path, (b) overlap-
+  avoidance shifts it, (c) constraint clamps it back, (d) size clamp for
+  oversized persisted geometry.
+- **Manual (`runIde`):**
+  - Start walkthrough → drag popup → click Next → popup stays where dragged.
+  - Close walkthrough → start another → popup re-appears at last drag position.
+  - Drag popup over a future target line → click Next → popup nudges aside.
+  - Restart IDE → start walkthrough → popup re-appears at last drag position.
+
+## Non-goals
+
+- Persisting per-walkthrough geometry. Geometry is project-wide; all
+  walkthroughs in a project share the same remembered placement.
+- Persisting connector style, palette overrides, or other UI state.
+- Multi-window persistence subtleties (e.g., remembering different positions
+  per monitor). Screen coords plus constraint clamping are accepted as
+  sufficient.

--- a/docs/superpowers/specs/2026-05-18-popup-geometry-persistence-design.md
+++ b/docs/superpowers/specs/2026-05-18-popup-geometry-persistence-design.md
@@ -2,11 +2,12 @@
 
 ## Goal
 
-Persist the walkthrough popup's position and size in project-scoped settings so
-the popup re-appears in the same place across walkthrough sessions (and across
-IDE restarts), not just across Next/Previous clicks within a single session. On
-every show, apply the persisted geometry and then nudge the popup out of the way
-if it would overlap the target line. Save the geometry on every drag and resize.
+Persist the walkthrough popup's position and size in application-scoped
+settings so the popup re-appears in the same place across walkthrough sessions
+(and across IDE restarts), not just across Next/Previous clicks within a single
+session. On every show, apply the persisted geometry and then nudge the popup
+out of the way if it would overlap the target line. Save the geometry on every
+drag and resize.
 
 ## Background
 
@@ -19,19 +20,18 @@ another, and it does not survive an IDE restart. Issue
 [#23](https://github.com/forketyfork/walkthrough-plugin/issues/23) tracks the
 broader bug.
 
-The plugin already has two relevant pieces:
-
-- `WalkthroughSettings` — an application-level `PersistentStateComponent` for
-  the color palette. Wrong scope for popup geometry (per-application, not
-  per-project).
-- `WalkthroughHistoryService` — a project-level service that writes to
-  `.idea/walkthroughs/`. Correct pattern to mirror for project-scoped state.
+The plugin already has `WalkthroughSettings` — an application-level
+`PersistentStateComponent` registered in `plugin.xml` with storage at
+`com.forketyfork.walkthrough.settings.xml`. It currently holds one field
+(`selectedPaletteId`). Extending it with the four geometry fields is the
+smallest viable change and keeps "user preferences for the popup" in one
+place.
 
 ## Decisions
 
 | Decision                       | Choice                                                  |
 | ------------------------------ | ------------------------------------------------------- |
-| Scope                          | Per-project (under `.idea/`)                            |
+| Scope                          | Application-wide (extend existing `WalkthroughSettings`) |
 | Coordinate system              | Absolute screen coordinates                             |
 | First-time fallback            | Existing `movePopupNearItem` placement                  |
 | Behavior on Next within session| Same as first show: load → avoid overlap → constrain    |
@@ -40,29 +40,37 @@ The plugin already has two relevant pieces:
 
 ## Architecture
 
-### New component: `WalkthroughPopupGeometryService`
+### Extend `WalkthroughSettings`
 
-Project-level `PersistentStateComponent` storing the most recently observed
-popup geometry.
+Add the popup geometry to the existing application-level
+`PersistentStateComponent`. No new service, no new storage file, no
+`plugin.xml` change.
 
-- Registered in `plugin.xml` as a `projectService`.
-- `@Storage("walkthroughPopup.xml")` → file lives under `.idea/walkthroughPopup.xml`.
-- State fields: `x: Int`, `y: Int`, `width: Int`, `height: Int`.
-- "Unset" sentinel: all four fields default to `Int.MIN_VALUE`. The service
-  exposes `loadGeometry(): PopupGeometry?` returning `null` when unset.
-- Mutation API: `saveGeometry(x, y, width, height)` updates state in place.
-  Writes are idempotent — saving the same geometry twice is a no-op.
+- Add four fields to `WalkthroughSettings.State`: `popupX: Int`, `popupY: Int`,
+  `popupWidth: Int`, `popupHeight: Int`. All default to `Int.MIN_VALUE` as the
+  "unset" sentinel.
+- Add a top-level `PopupGeometry` data class in the same file:
 
-```kotlin
-internal data class PopupGeometry(val x: Int, val y: Int, val width: Int, val height: Int)
-```
+  ```kotlin
+  internal data class PopupGeometry(val x: Int, val y: Int, val width: Int, val height: Int)
+  ```
+
+- Add two methods on `WalkthroughSettings`:
+  - `loadGeometry(): PopupGeometry?` — returns `null` when any field is
+    `Int.MIN_VALUE`, else a populated `PopupGeometry`.
+  - `saveGeometry(geometry: PopupGeometry)` — writes the four fields. Writes
+    are idempotent: if the incoming values equal current state, return without
+    touching state. No listener notification is needed (only the orchestrator
+    consumes this, and it reads on each show).
+- The existing palette listener and `loadState` palette validation are left
+  alone.
 
 ### Unified placement pipeline
 
 `WalkthroughOrchestrator` invokes a single `applyPopupGeometryForItem` function
 both on first show and on every Next/Previous navigation:
 
-1. **Load** persisted geometry from `WalkthroughPopupGeometryService`.
+1. **Load** persisted geometry via `WalkthroughSettings.getInstance().loadGeometry()`.
 2. **Choose starting rectangle:**
    - If persisted geometry exists, use it.
    - Else, fall back to `movePopupNearItem` (existing default placement).
@@ -102,8 +110,9 @@ interaction completes:
   handle). This avoids firing on stray clicks elsewhere on the popup.
 - Signature stays `() -> Unit`. Inside the callback the orchestrator queries
   `popup.popupLocationOnScreen()` and `resolvePopupSize(popup)` and calls
-  `geometryService.saveGeometry(x, y, w, h)`. Keeping the interaction module
-  ignorant of the geometry service preserves the existing module boundary.
+  `WalkthroughSettings.getInstance().saveGeometry(...)`. Keeping the
+  interaction module ignorant of the settings service preserves the existing
+  module boundary.
 
 The result: exactly one save per completed drag and one per completed resize,
 regardless of how many `mouseDragged` events fired between press and release.
@@ -112,19 +121,21 @@ no-op because the persisted geometry is unchanged.
 
 ### Files touched
 
-| File                                       | Change                                                                                                                              |
-| ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `WalkthroughPopupGeometryService.kt` (new) | `PersistentStateComponent` with load/save API and `PopupGeometry` data class.                                                       |
-| `META-INF/plugin.xml`                      | Register `<projectService>` for `WalkthroughPopupGeometryService`.                                                                  |
-| `WalkthroughOrchestrator.kt`               | Remove `userMovedPopup` and `onPopupUserMoved`. Replace `repositionPopupForItem` with `applyPopupGeometryForItem`. Wire save hook. |
-| `WalkthroughPopupPlacement.kt`             | Add a helper that takes a starting `Rectangle`, target line, editor, and returns the constrained, overlap-avoided rectangle.        |
-| `WalkthroughPopupInteraction.kt`           | Rename `onPopupMoved` → `onGeometryChanged`; pass screen rectangle to the callback.                                                 |
+| File                             | Change                                                                                                                              |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `WalkthroughSettings.kt`         | Add `popupX/Y/Width/Height` fields to `State`; add `PopupGeometry` data class; add `loadGeometry()` and `saveGeometry()` methods.  |
+| `WalkthroughOrchestrator.kt`     | Remove `userMovedPopup` and `onPopupUserMoved`. Replace `repositionPopupForItem` with `applyPopupGeometryForItem`. Wire save hook. |
+| `WalkthroughPopupPlacement.kt`   | Add a helper that takes a starting `Rectangle`, target line, editor, and returns the constrained, overlap-avoided rectangle.        |
+| `WalkthroughPopupInteraction.kt` | Rename `onPopupMoved` → `onInteractionEnd`; drop `onLocationChanged` param from `movePopupBy` / `resizePopupBy`; fire callback from `mouseReleased`. |
+
+No `plugin.xml` change is required — `WalkthroughSettings` is already
+registered as an `applicationService`.
 
 ## Edge cases
 
-- **No persisted geometry yet (first walkthrough in project):** fall back to
-  `movePopupNearItem`. The result is then persisted, so the second walkthrough
-  starts from the same spot.
+- **No persisted geometry yet (first walkthrough ever on this IDE install):**
+  fall back to `movePopupNearItem`. The result is then persisted, so the next
+  walkthrough — in this or any other project — starts from the same spot.
 - **Persisted position is off-screen (monitor unplugged, IDE window moved):**
   `constrainPopupScreenLocation` clamps the popup back inside the root pane.
   The clamped rectangle is then persisted, so the next show is stable.
@@ -146,13 +157,16 @@ no-op because the persisted geometry is unchanged.
 - **Manual (`runIde`):**
   - Start walkthrough → drag popup → click Next → popup stays where dragged.
   - Close walkthrough → start another → popup re-appears at last drag position.
+  - Close walkthrough → open a different project → start walkthrough → popup
+    re-appears at the same drag position (application-wide setting).
   - Drag popup over a future target line → click Next → popup nudges aside.
   - Restart IDE → start walkthrough → popup re-appears at last drag position.
 
 ## Non-goals
 
-- Persisting per-walkthrough geometry. Geometry is project-wide; all
-  walkthroughs in a project share the same remembered placement.
+- Persisting per-project or per-walkthrough geometry. Geometry is
+  application-wide; all walkthroughs across all projects on this IDE
+  installation share the same remembered placement.
 - Persisting connector style, palette overrides, or other UI state.
 - Multi-window persistence subtleties (e.g., remembering different positions
   per monitor). Screen coords plus constraint clamping are accepted as

--- a/justfile
+++ b/justfile
@@ -20,8 +20,9 @@ verify:
 test:
     ./gradlew test
 
-# Run Detekt static analysis
+# Run all static analysis CI runs: nix flake check (markdownlint, shellcheck, actionlint, alejandra, statix) and Detekt
 lint:
+    nix flake check
     ./gradlew detekt
 
 # Clean build artifacts

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughOrchestrator.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughOrchestrator.kt
@@ -62,12 +62,18 @@ fun showWalkthroughSession(
     var popupRef: WalkthroughPopupSurface? = null
     var currentEditor = firstTarget.editor
     var pendingNavigationId = 0
+    var userMovedPopup = false
 
     fun repaintPopup() {
         popupRef?.let { popup ->
             popup.refreshBounds()
             popup.repaint()
         }
+    }
+
+    fun onPopupUserMoved() {
+        userMovedPopup = true
+        repaintPopup()
     }
 
     fun updatePopupPalette(palette: WalkthroughPalette) {
@@ -86,7 +92,12 @@ fun showWalkthroughSession(
         currentEditor = target.editor
         popup.update(currentEditor, target.popupItem)
         popup.connectorHidden = false
-        movePopupNearItem(popup, currentEditor, target.popupItem, ::repaintPopup)
+        if (userMovedPopup) {
+            popup.moveToFitScreen(currentEditor)
+            repaintPopup()
+        } else {
+            movePopupNearItem(popup, currentEditor, target.popupItem, ::repaintPopup)
+        }
     }
 
     fun scheduleItemNavigation(item: WalkthroughItem) {
@@ -114,7 +125,7 @@ fun showWalkthroughSession(
         panel = panel,
         popupProvider = { popupRef },
         editorProvider = { currentEditor },
-        onPopupMoved = ::repaintPopup
+        onPopupMoved = ::onPopupUserMoved
     )
 
     project.messageBus.connect(sessionDisposable).subscribe(

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughOrchestrator.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughOrchestrator.kt
@@ -12,6 +12,7 @@ import com.intellij.openapi.util.Disposer
 import org.jetbrains.jewel.bridge.JewelComposePanel
 import java.awt.Color as AwtColor
 import java.awt.Dimension
+import java.awt.Point
 import javax.swing.JComponent
 import javax.swing.SwingUtilities
 
@@ -62,18 +63,12 @@ fun showWalkthroughSession(
     var popupRef: WalkthroughPopupSurface? = null
     var currentEditor = firstTarget.editor
     var pendingNavigationId = 0
-    var userMovedPopup = false
 
     fun repaintPopup() {
         popupRef?.let { popup ->
             popup.refreshBounds()
             popup.repaint()
         }
-    }
-
-    fun onPopupUserMoved() {
-        userMovedPopup = true
-        repaintPopup()
     }
 
     fun updatePopupPalette(palette: WalkthroughPalette) {
@@ -92,7 +87,7 @@ fun showWalkthroughSession(
         currentEditor = target.editor
         popup.update(currentEditor, target.popupItem)
         popup.connectorHidden = false
-        repositionPopupForItem(popup, currentEditor, target.popupItem, userMovedPopup, ::repaintPopup)
+        applyPopupGeometryForItem(popup, currentEditor, target.popupItem)
     }
 
     fun scheduleItemNavigation(item: WalkthroughItem) {
@@ -120,7 +115,7 @@ fun showWalkthroughSession(
         panel = panel,
         popupProvider = { popupRef },
         editorProvider = { currentEditor },
-        onPopupMoved = ::onPopupUserMoved
+        onInteractionEnd = { saveCurrentGeometry(popupRef) }
     )
 
     project.messageBus.connect(sessionDisposable).subscribe(
@@ -153,22 +148,53 @@ fun showWalkthroughSession(
     popupRef = popup
     Disposer.register(sessionDisposable, popup)
     popup.update(currentEditor, firstTarget.popupItem)
-    movePopupNearItem(popup, currentEditor, firstTarget.popupItem, ::repaintPopup)
+    applyPopupGeometryForItem(popup, currentEditor, firstTarget.popupItem)
+    repaintPopup()
     return session
 }
 
-private fun repositionPopupForItem(
+private fun saveCurrentGeometry(popup: WalkthroughPopupSurface?) {
+    val location = popup?.popupLocationOnScreen() ?: return
+    val size = popup.let(::resolvePopupSize) ?: return
+    WalkthroughSettings.getInstance().saveGeometry(
+        PopupGeometry(location.x, location.y, size.width, size.height)
+    )
+}
+
+private fun applyPopupGeometryForItem(
     popup: WalkthroughPopupSurface,
     editor: Editor,
-    popupItem: WalkthroughItem,
-    userMovedPopup: Boolean,
-    onRepaint: () -> Unit
+    item: WalkthroughItem
 ) {
-    if (userMovedPopup) {
-        popup.moveToFitScreen(editor)
-        onRepaint()
+    val settings = WalkthroughSettings.getInstance()
+    val persisted = settings.loadGeometry()
+
+    if (persisted == null) {
+        movePopupNearItem(popup, editor, item)
     } else {
-        movePopupNearItem(popup, editor, popupItem, onRepaint)
+        val rootPane = SwingUtilities.getRootPane(editor.contentComponent)
+        val maxWidth = rootPane?.let { it.width - 2 * WalkthroughPopupLayout.VIEWPORT_PADDING }
+            ?: Int.MAX_VALUE
+        val maxHeight = rootPane?.let { it.height - 2 * WalkthroughPopupLayout.VIEWPORT_PADDING }
+            ?: Int.MAX_VALUE
+        val clampedSize = clampPopupSize(
+            Dimension(persisted.width, persisted.height),
+            maxWidth = maxWidth,
+            maxHeight = maxHeight
+        )
+        popup.popupSize = clampedSize
+        val avoided = avoidLineOverlap(Point(persisted.x, persisted.y), clampedSize, editor, item.line)
+        val constrained = constrainPopupScreenLocation(editor, avoided, clampedSize)
+        val reAvoided = avoidLineOverlap(constrained, clampedSize, editor, item.line)
+        val finalPoint = constrainPopupScreenLocation(editor, reAvoided, clampedSize)
+        popup.show(editor, finalPoint)
+    }
+
+    val finalLocation = popup.popupLocationOnScreen() ?: return
+    val finalSize = resolvePopupSize(popup) ?: return
+    val finalGeometry = PopupGeometry(finalLocation.x, finalLocation.y, finalSize.width, finalSize.height)
+    if (persisted != finalGeometry) {
+        settings.saveGeometry(finalGeometry)
     }
 }
 

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughOrchestrator.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughOrchestrator.kt
@@ -92,12 +92,7 @@ fun showWalkthroughSession(
         currentEditor = target.editor
         popup.update(currentEditor, target.popupItem)
         popup.connectorHidden = false
-        if (userMovedPopup) {
-            popup.moveToFitScreen(currentEditor)
-            repaintPopup()
-        } else {
-            movePopupNearItem(popup, currentEditor, target.popupItem, ::repaintPopup)
-        }
+        repositionPopupForItem(popup, currentEditor, target.popupItem, userMovedPopup, ::repaintPopup)
     }
 
     fun scheduleItemNavigation(item: WalkthroughItem) {
@@ -160,6 +155,21 @@ fun showWalkthroughSession(
     popup.update(currentEditor, firstTarget.popupItem)
     movePopupNearItem(popup, currentEditor, firstTarget.popupItem, ::repaintPopup)
     return session
+}
+
+private fun repositionPopupForItem(
+    popup: WalkthroughPopupSurface,
+    editor: Editor,
+    popupItem: WalkthroughItem,
+    userMovedPopup: Boolean,
+    onRepaint: () -> Unit
+) {
+    if (userMovedPopup) {
+        popup.moveToFitScreen(editor)
+        onRepaint()
+    } else {
+        movePopupNearItem(popup, editor, popupItem, onRepaint)
+    }
 }
 
 private fun createWalkthroughPanel(

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughOrchestrator.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughOrchestrator.kt
@@ -155,7 +155,7 @@ fun showWalkthroughSession(
 
 private fun saveCurrentGeometry(popup: WalkthroughPopupSurface?) {
     val location = popup?.popupLocationOnScreen() ?: return
-    val size = popup.let(::resolvePopupSize) ?: return
+    val size = resolvePopupSize(popup) ?: return
     WalkthroughSettings.getInstance().saveGeometry(
         PopupGeometry(location.x, location.y, size.width, size.height)
     )

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupInteraction.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupInteraction.kt
@@ -44,7 +44,7 @@ internal fun installPopupInteractionHandler(
     panel: JComponent,
     popupProvider: () -> WalkthroughPopupSurface?,
     editorProvider: () -> Editor,
-    onPopupMoved: () -> Unit
+    onInteractionEnd: () -> Unit
 ) {
     var lastScreenPoint: Point? = null
     var interactionMode: PopupInteractionMode? = null
@@ -74,8 +74,7 @@ internal fun installPopupInteractionHandler(
                     popup = popup,
                     editor = editorProvider(),
                     deltaX = (currentScreenPoint.x - previousScreenPoint.x).toFloat(),
-                    deltaY = (currentScreenPoint.y - previousScreenPoint.y).toFloat(),
-                    onLocationChanged = onPopupMoved
+                    deltaY = (currentScreenPoint.y - previousScreenPoint.y).toFloat()
                 )
 
                 PopupInteractionMode.Resize -> resizePopupBy(
@@ -83,8 +82,7 @@ internal fun installPopupInteractionHandler(
                     panel = panel,
                     editor = editorProvider(),
                     deltaX = (currentScreenPoint.x - previousScreenPoint.x).toFloat(),
-                    deltaY = (currentScreenPoint.y - previousScreenPoint.y).toFloat(),
-                    onLocationChanged = onPopupMoved
+                    deltaY = (currentScreenPoint.y - previousScreenPoint.y).toFloat()
                 )
             }
             lastScreenPoint = currentScreenPoint
@@ -95,9 +93,13 @@ internal fun installPopupInteractionHandler(
         }
 
         override fun mouseReleased(event: MouseEvent) {
+            val hadInteraction = interactionMode != null
             interactionMode = null
             lastScreenPoint = null
             updateInteractionCursor(panel, event.component, event.point)
+            if (hadInteraction) {
+                onInteractionEnd()
+            }
         }
 
         override fun mouseExited(event: MouseEvent) {
@@ -174,8 +176,7 @@ private fun resizePopupBy(
     panel: JComponent,
     editor: Editor,
     deltaX: Float,
-    deltaY: Float,
-    onLocationChanged: (() -> Unit)? = null
+    deltaY: Float
 ) {
     val currentLocation = popup.popupLocationOnScreen() ?: return
     val currentSize = resolvePopupSize(popup)
@@ -203,5 +204,4 @@ private fun resizePopupBy(
     panel.revalidate()
     popup.popupSize = targetSize
     popup.moveToFitScreen(editor)
-    onLocationChanged?.invoke()
 }

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupPlacement.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupPlacement.kt
@@ -34,8 +34,7 @@ internal fun movePopupBy(
     popup: WalkthroughPopupSurface,
     editor: Editor,
     deltaX: Float,
-    deltaY: Float,
-    onLocationChanged: (() -> Unit)? = null
+    deltaY: Float
 ) {
     val currentLocation = popup.popupLocationOnScreen() ?: return
     val popupSize = resolvePopupSize(popup) ?: WalkthroughPopupLayout.fallbackSize
@@ -44,7 +43,6 @@ internal fun movePopupBy(
         currentLocation.y + deltaY.roundToInt()
     )
     popup.setPopupScreenLocation(constrainPopupScreenLocation(editor, movedPoint, popupSize))
-    onLocationChanged?.invoke()
 }
 
 internal fun resolvePopupSize(popup: WalkthroughPopupSurface): Dimension? =

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupPlacement.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupPlacement.kt
@@ -76,3 +76,14 @@ internal fun constrainPopupScreenLocation(
     }
     return constrainedLocation
 }
+
+internal fun clampPopupSize(size: Dimension, maxWidth: Int, maxHeight: Int): Dimension {
+    val minWidth = WalkthroughPopupLayout.MINIMUM_WIDTH_PX
+    val minHeight = WalkthroughPopupLayout.MINIMUM_HEIGHT_PX
+    val effectiveMaxWidth = maxWidth.coerceAtLeast(minWidth)
+    val effectiveMaxHeight = maxHeight.coerceAtLeast(minHeight)
+    return Dimension(
+        size.width.coerceIn(minWidth, effectiveMaxWidth),
+        size.height.coerceIn(minHeight, effectiveMaxHeight)
+    )
+}

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupPlacement.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupPlacement.kt
@@ -9,8 +9,7 @@ import kotlin.math.roundToInt
 internal fun movePopupNearItem(
     popup: WalkthroughPopupSurface,
     editor: Editor,
-    item: WalkthroughItem,
-    onLocationChanged: (() -> Unit)? = null
+    item: WalkthroughItem
 ) {
     popup.content.revalidate()
     popup.content.doLayout()
@@ -27,7 +26,6 @@ internal fun movePopupNearItem(
     val reAvoidedPoint = avoidLineOverlap(constrainedPoint, popupSize, editor, item.line)
     val finalPoint = constrainPopupScreenLocation(editor, reAvoidedPoint, popupSize)
     popup.show(editor, finalPoint)
-    onLocationChanged?.invoke()
 }
 
 internal fun movePopupBy(

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughSettings.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughSettings.kt
@@ -5,12 +5,15 @@ import com.intellij.openapi.components.PersistentStateComponent
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
 
+internal data class PopupGeometry(val x: Int, val y: Int, val width: Int, val height: Int)
+
 @State(
     name = "com.forketyfork.walkthrough.WalkthroughSettings",
     storages = [Storage("com.forketyfork.walkthrough.settings.xml")]
 )
 internal class WalkthroughSettings : PersistentStateComponent<WalkthroughSettings.State> {
-    private var state = State()
+    internal var state = State()
+        private set
 
     var selectedPaletteId: String
         get() = state.selectedPaletteId
@@ -26,6 +29,27 @@ internal class WalkthroughSettings : PersistentStateComponent<WalkthroughSetting
     val selectedPalette: WalkthroughPalette
         get() = WalkthroughPalettes.byId(selectedPaletteId)
 
+    fun loadGeometry(): PopupGeometry? {
+        val s = state
+        val fields = intArrayOf(s.popupX, s.popupY, s.popupWidth, s.popupHeight)
+        if (fields.any { it == Int.MIN_VALUE }) {
+            return null
+        }
+        return PopupGeometry(s.popupX, s.popupY, s.popupWidth, s.popupHeight)
+    }
+
+    fun saveGeometry(geometry: PopupGeometry) {
+        val s = state
+        val current = PopupGeometry(s.popupX, s.popupY, s.popupWidth, s.popupHeight)
+        if (current == geometry) {
+            return
+        }
+        s.popupX = geometry.x
+        s.popupY = geometry.y
+        s.popupWidth = geometry.width
+        s.popupHeight = geometry.height
+    }
+
     override fun getState(): State = state
 
     override fun loadState(state: State) {
@@ -35,6 +59,10 @@ internal class WalkthroughSettings : PersistentStateComponent<WalkthroughSetting
 
     class State {
         var selectedPaletteId: String = WalkthroughPalettes.default.id
+        var popupX: Int = Int.MIN_VALUE
+        var popupY: Int = Int.MIN_VALUE
+        var popupWidth: Int = Int.MIN_VALUE
+        var popupHeight: Int = Int.MIN_VALUE
     }
 
     private fun notifyPaletteChanged(palette: WalkthroughPalette) {

--- a/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughPopupPlacementTest.kt
+++ b/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughPopupPlacementTest.kt
@@ -1,0 +1,47 @@
+package com.forketyfork.walkthrough
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.awt.Dimension
+
+class WalkthroughPopupPlacementTest {
+
+    private val minWidth = WalkthroughPopupLayout.MINIMUM_WIDTH_PX
+    private val minHeight = WalkthroughPopupLayout.MINIMUM_HEIGHT_PX
+
+    @Test
+    fun clampPopupSizePreservesSizeWithinBounds() {
+        val clamped = clampPopupSize(Dimension(720, 480), maxWidth = 1200, maxHeight = 900)
+
+        assertEquals(Dimension(720, 480), clamped)
+    }
+
+    @Test
+    fun clampPopupSizeRaisesBelowMinimumToMinimum() {
+        val clamped = clampPopupSize(
+            Dimension(minWidth - 50, minHeight - 50),
+            maxWidth = 1200,
+            maxHeight = 900
+        )
+
+        assertEquals(Dimension(minWidth, minHeight), clamped)
+    }
+
+    @Test
+    fun clampPopupSizeLowersAboveMaximumToMaximum() {
+        val clamped = clampPopupSize(Dimension(2000, 1500), maxWidth = 1200, maxHeight = 900)
+
+        assertEquals(Dimension(1200, 900), clamped)
+    }
+
+    @Test
+    fun clampPopupSizeUsesMinimumWhenMaxIsBelowMinimum() {
+        val clamped = clampPopupSize(
+            Dimension(800, 500),
+            maxWidth = minWidth - 100,
+            maxHeight = minHeight - 100
+        )
+
+        assertEquals(Dimension(minWidth, minHeight), clamped)
+    }
+}

--- a/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughSettingsGeometryTest.kt
+++ b/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughSettingsGeometryTest.kt
@@ -1,0 +1,62 @@
+package com.forketyfork.walkthrough
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+
+class WalkthroughSettingsGeometryTest {
+
+    @Test
+    fun loadGeometryReturnsNullWhenStateIsUnset() {
+        val settings = WalkthroughSettings()
+        assertNull(settings.loadGeometry())
+    }
+
+    @Test
+    fun saveGeometryThenLoadGeometryRoundTrips() {
+        val settings = WalkthroughSettings()
+        val geometry = PopupGeometry(x = 120, y = 240, width = 720, height = 480)
+
+        settings.saveGeometry(geometry)
+
+        assertEquals(geometry, settings.loadGeometry())
+    }
+
+    @Test
+    fun loadGeometryReturnsNullWhenAnyFieldIsSentinel() {
+        val settings = WalkthroughSettings()
+        settings.saveGeometry(PopupGeometry(x = 100, y = 100, width = 800, height = 600))
+        val state = settings.state
+        state.popupX = Int.MIN_VALUE
+
+        assertNull(settings.loadGeometry())
+    }
+
+    @Test
+    fun stateSerializationRoundTripsGeometry() {
+        val original = WalkthroughSettings()
+        original.saveGeometry(PopupGeometry(x = 10, y = 20, width = 600, height = 400))
+        val serialized = original.state
+
+        val restored = WalkthroughSettings()
+        restored.loadState(serialized)
+
+        assertEquals(
+            PopupGeometry(x = 10, y = 20, width = 600, height = 400),
+            restored.loadGeometry()
+        )
+    }
+
+    @Test
+    fun saveGeometryIsIdempotent() {
+        val settings = WalkthroughSettings()
+        val geometry = PopupGeometry(x = 1, y = 2, width = 600, height = 400)
+        settings.saveGeometry(geometry)
+        val stateBefore = settings.state
+
+        settings.saveGeometry(geometry)
+
+        assertSame(stateBefore, settings.state)
+    }
+}


### PR DESCRIPTION
## Summary

- Persist the walkthrough popup's screen position and size in `WalkthroughSettings` (application-wide) so the popup re-appears in the same place across Next clicks, walkthrough sessions, project switches, and IDE restarts.
- On every show — first and Next/Previous — load persisted geometry (or fall back to `movePopupNearItem` on the very first walkthrough), clamp size to the editor root pane, run the existing overlap-avoidance against the current target line, constrain to the root pane, apply, and persist back when the result differs.
- Save geometry once per gesture on `mouseReleased` after a drag or resize (not on every motion event).
- Remove the in-memory `userMovedPopup` flag that the previous fix introduced — persisted geometry replaces it.

Spec: `docs/superpowers/specs/2026-05-18-popup-geometry-persistence-design.md`
Plan: `docs/superpowers/plans/2026-05-18-popup-geometry-persistence.md`

Fixes #23

## Test plan

- [ ] `just lint && just build && just test`
- [ ] In `runIde`: start a walkthrough, drag the popup, click Next — popup stays where you put it (only nudging aside if it overlaps the new target line).
- [ ] Close the walkthrough, start another — popup re-appears at the last dragged position.
- [ ] Open a different project, start a walkthrough — popup re-appears at the same dragged position (application-wide).
- [ ] Resize the popup, close the walkthrough, start another — popup re-appears at the new size.
- [ ] Restart the sandbox IDE, start a walkthrough — popup re-appears at the last position and size.
- [ ] Drag the popup over a future target line, click Next — popup nudges above or below the line.