### PR TITLE
feat(popup): enlarge default size and relocate locate icon

### DIFF
--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughItem.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughItem.kt
@@ -3,7 +3,7 @@ package com.forketyfork.walkthrough
 import java.awt.Dimension
 
 internal object WalkthroughPopupLayout {
-    val fallbackSize = Dimension(560, 300)
+    val fallbackSize = Dimension(560, 360)
     const val MINIMUM_WIDTH_PX = 520
     const val MINIMUM_HEIGHT_PX = 260
     const val VIEWPORT_PADDING = 18

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupContent.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupContent.kt
@@ -217,16 +217,6 @@ private fun WalkthroughPopupFrame(
                 .padding(WalkthroughPopupContentStyle.closeButtonPadding),
             onClick = onClose
         )
-
-        if (item.file != null || item.line != null) {
-            GoToSourceButton(
-                modifier = Modifier
-                    .align(Alignment.BottomEnd)
-                    .padding(WalkthroughPopupContentStyle.closeButtonPadding),
-                onClick = onNavigateToSource
-            )
-        }
-
         Column(
             modifier = Modifier
                 .fillMaxSize()
@@ -245,13 +235,17 @@ private fun WalkthroughPopupFrame(
                 scrollState = scrollState,
                 showScrollbar = showScrollbar
             )
-            if (items.size > 1) {
+            val showNavigation = items.size > 1
+            val sourceCallback = onNavigateToSource.takeIf { item.file != null || item.line != null }
+            if (showNavigation || sourceCallback != null) {
                 WalkthroughPopupNavigation(
+                    showNavigation = showNavigation,
                     currentIndex = currentIndex,
                     lastIndex = items.lastIndex,
                     palette = palette,
                     onPrevious = onPrevious,
-                    onNext = onNext
+                    onNext = onNext,
+                    onNavigateToSource = sourceCallback
                 )
             }
             if (acceptsQuestions) {

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupWidgets.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupWidgets.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentWidth
@@ -68,7 +69,6 @@ private object WalkthroughWidgetStyle {
     val questionRowSpacing = 8.dp
     val questionFieldRadius = 18.dp
     val questionFieldPaddingHorizontal = 14.dp
-    val questionFieldPaddingVertical = 10.dp
     val questionFieldTextSize = 13.sp
     const val QUESTION_FIELD_BACKGROUND_ALPHA = 0.12f
     const val QUESTION_FIELD_BORDER_ALPHA = 0.2f
@@ -83,31 +83,38 @@ private object WalkthroughWidgetStyle {
 
 @Composable
 internal fun WalkthroughPopupNavigation(
+    showNavigation: Boolean,
     currentIndex: Int,
     lastIndex: Int,
     palette: WalkthroughPalette,
     onPrevious: () -> Unit,
-    onNext: () -> Unit
+    onNext: () -> Unit,
+    onNavigateToSource: (() -> Unit)?
 ) {
     Row(
         horizontalArrangement = Arrangement.spacedBy(WalkthroughWidgetStyle.navigationSpacing),
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier.wrapContentWidth()
     ) {
-        AiNavButton(
-            label = "Previous",
-            enabled = currentIndex > 0,
-            emphasized = false,
-            palette = palette,
-            onClick = onPrevious
-        )
-        AiNavButton(
-            label = "Next",
-            enabled = currentIndex < lastIndex,
-            emphasized = true,
-            palette = palette,
-            onClick = onNext
-        )
+        if (showNavigation) {
+            AiNavButton(
+                label = "Previous",
+                enabled = currentIndex > 0,
+                emphasized = false,
+                palette = palette,
+                onClick = onPrevious
+            )
+            AiNavButton(
+                label = "Next",
+                enabled = currentIndex < lastIndex,
+                emphasized = true,
+                palette = palette,
+                onClick = onNext
+            )
+        }
+        if (onNavigateToSource != null) {
+            GoToSourceButton(onClick = onNavigateToSource)
+        }
     }
 }
 
@@ -159,7 +166,7 @@ internal fun AiCloseButton(modifier: Modifier = Modifier, onClick: () -> Unit) {
 internal fun GoToSourceButton(modifier: Modifier = Modifier, onClick: () -> Unit) {
     Box(
         modifier = modifier
-            .size(WalkthroughWidgetStyle.closeButtonSize)
+            .size(WalkthroughWidgetStyle.sendButtonSize)
             .clip(CircleShape)
             .background(Color.White.copy(alpha = WalkthroughWidgetStyle.CLOSE_BUTTON_BACKGROUND_ALPHA))
             .border(
@@ -269,6 +276,7 @@ private fun QuestionTextField(
 ) {
     Box(
         modifier = modifier
+            .height(WalkthroughWidgetStyle.sendButtonSize)
             .clip(RoundedCornerShape(WalkthroughWidgetStyle.questionFieldRadius))
             .background(
                 Color.White.copy(alpha = WalkthroughWidgetStyle.QUESTION_FIELD_BACKGROUND_ALPHA),
@@ -279,10 +287,8 @@ private fun QuestionTextField(
                 Color.White.copy(alpha = WalkthroughWidgetStyle.QUESTION_FIELD_BORDER_ALPHA),
                 RoundedCornerShape(WalkthroughWidgetStyle.questionFieldRadius)
             )
-            .padding(
-                horizontal = WalkthroughWidgetStyle.questionFieldPaddingHorizontal,
-                vertical = WalkthroughWidgetStyle.questionFieldPaddingVertical
-            )
+            .padding(horizontal = WalkthroughWidgetStyle.questionFieldPaddingHorizontal),
+        contentAlignment = Alignment.CenterStart
     ) {
         BasicTextField(
             value = text,


### PR DESCRIPTION
## Solution
- Raise the popup's `fallbackSize` height from 300 to 360 so the body area shows at least four lines of 22 sp markdown text once the surrounding chrome is accounted for.
- Drop the absolute bottom-right placement of `GoToSourceButton` and render it inline in the navigation row, right after the Next pill. The button now uses `sendButtonSize` (34 dp) so it matches the nav button height.
- Render the navigation row whenever the current item has source info, even for single-step walkthroughs. Previous/Next render only when there are multiple items.
- Pin the question input field to the same 34 dp height as the send button so the text input and send button line up cleanly.

Fixes #22 

## Test plan
- [x] Run a multi-step walkthrough where each step has `file`/`line` set; confirm the locate icon sits to the right of Next and lines up vertically with the nav pills.
- [ ] Run a single-step walkthrough with source info; confirm the locate icon appears on its own in the row that would normally hold Previous/Next.
- [ ] Run a multi-step walkthrough without source info; confirm Previous/Next render as before with no icon.
- [ ] Open a walkthrough that accepts questions; confirm the question input row no longer contains the locate icon and the text field matches the send button height.
- [ ] On first open, confirm the popup is tall enough to display at least four lines of body text in a step with several paragraphs.
