### PR TITLE
fix(walkthrough): recover question waits

### DIFF
--- a/src/main/kotlin/com/forketyfork/walkthrough/ShowWalkthroughItemsToolset.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/ShowWalkthroughItemsToolset.kt
@@ -37,6 +37,8 @@ private data class ToolDiffWalkthroughDescriptorJson(
     val rightCommit: String?
 )
 
+private const val QUESTION_TOOL_REFRESH_TIMEOUT_MILLIS = 110_000L
+
 class ShowWalkthroughItemsToolset : McpToolset {
     // Discovered and invoked via reflection by the MCP server framework
     @Suppress("unused")
@@ -157,6 +159,8 @@ class ShowWalkthroughItemsToolset : McpToolset {
         "Suspends until the user types a follow-up question into the active walkthrough popup " +
             "and presses Send, then returns the question text along with the label of the step " +
             "the user was viewing. Returns 'dismissed' if the user closes the popup before asking. " +
+            "Returns 'waiting-expired' before Codex's tool timeout if no question arrives; " +
+            "when that happens, immediately call this tool again with the same walkthroughId. " +
             "Call this immediately after show_walkthrough_items or show_diff_walkthrough_items returns, " +
             "and call it again after each insert_walkthrough_tangents response. " +
             "Keep waiting in this loop until this tool returns dismissed. " +
@@ -168,17 +172,25 @@ class ShowWalkthroughItemsToolset : McpToolset {
         val project = requireProject()
         val registry = WalkthroughSessionRegistry.getInstance(project)
         val session = registry.get(walkthroughId)
-        val question = when {
-            session != null -> session.awaitQuestion().also {
+        val result = when {
+            session != null -> session.awaitQuestionResult(QUESTION_TOOL_REFRESH_TIMEOUT_MILLIS).also {
                 registry.consumeDismissed(walkthroughId)
             }
-            registry.consumeDismissed(walkthroughId) -> null
+            registry.consumeDismissed(walkthroughId) -> WalkthroughQuestionAwaitResult.Dismissed
             else -> mcpFail("Unknown walkthroughId: $walkthroughId")
         }
-        return question?.let {
-            val parent = it.parentLabel ?: "(unknown)"
-            "parentLabel=$parent\nquestion=${it.question}"
-        } ?: "dismissed"
+        return when (result) {
+            is WalkthroughQuestionAwaitResult.Received -> {
+                val parent = result.question.parentLabel ?: "(unknown)"
+                "parentLabel=$parent\nquestion=${result.question.question}"
+            }
+            WalkthroughQuestionAwaitResult.Dismissed -> "dismissed"
+            WalkthroughQuestionAwaitResult.WaitingExpired ->
+                "waiting-expired\nNo question arrived before the refresh timeout. " +
+                    "Call await_walkthrough_question again immediately with walkthroughId=$walkthroughId."
+            WalkthroughQuestionAwaitResult.Replaced ->
+                "waiting-replaced\nA newer await_walkthrough_question call is already listening."
+        }
     }
 
     @Suppress("unused")

--- a/src/main/kotlin/com/forketyfork/walkthrough/ShowWalkthroughItemsToolset.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/ShowWalkthroughItemsToolset.kt
@@ -39,6 +39,16 @@ private data class ToolDiffWalkthroughDescriptorJson(
 
 private const val QUESTION_TOOL_REFRESH_TIMEOUT_MILLIS = 110_000L
 
+private fun resolveAwaitQuestionResult(
+    result: WalkthroughQuestionAwaitResult,
+    wasDismissed: Boolean
+): WalkthroughQuestionAwaitResult =
+    if (wasDismissed && result == WalkthroughQuestionAwaitResult.WaitingExpired) {
+        WalkthroughQuestionAwaitResult.Dismissed
+    } else {
+        result
+    }
+
 class ShowWalkthroughItemsToolset : McpToolset {
     // Discovered and invoked via reflection by the MCP server framework
     @Suppress("unused")
@@ -173,9 +183,10 @@ class ShowWalkthroughItemsToolset : McpToolset {
         val registry = WalkthroughSessionRegistry.getInstance(project)
         val session = registry.get(walkthroughId)
         val result = when {
-            session != null -> session.awaitQuestionResult(QUESTION_TOOL_REFRESH_TIMEOUT_MILLIS).also {
-                registry.consumeDismissed(walkthroughId)
-            }
+            session != null -> resolveAwaitQuestionResult(
+                result = session.awaitQuestionResult(QUESTION_TOOL_REFRESH_TIMEOUT_MILLIS),
+                wasDismissed = registry.consumeDismissed(walkthroughId)
+            )
             registry.consumeDismissed(walkthroughId) -> WalkthroughQuestionAwaitResult.Dismissed
             else -> mcpFail("Unknown walkthroughId: $walkthroughId")
         }

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupContent.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupContent.kt
@@ -120,7 +120,7 @@ internal fun WalkthroughItemContent(
     val animationState = rememberPopupAnimationState()
     val scrollbarStyle = rememberPopupScrollbarStyle(palette)
     val showScrollbar = scrollState.maxValue > 0
-    val isLoading by session.loadingState
+    val questionStatus by session.questionStatusState
 
     LaunchedEffect(item) {
         scrollState.scrollTo(0)
@@ -134,7 +134,7 @@ internal fun WalkthroughItemContent(
             items = items,
             currentIndex = safeIndex,
             acceptsQuestions = session.acceptsQuestions,
-            isLoading = isLoading,
+            questionStatus = questionStatus,
             palette = palette,
             scrollState = scrollState,
             showScrollbar = showScrollbar,
@@ -193,7 +193,7 @@ private fun WalkthroughPopupFrame(
     items: List<WalkthroughItem>,
     currentIndex: Int,
     acceptsQuestions: Boolean,
-    isLoading: Boolean,
+    questionStatus: WalkthroughQuestionStatus,
     palette: WalkthroughPalette,
     scrollState: ScrollState,
     showScrollbar: Boolean,
@@ -250,7 +250,7 @@ private fun WalkthroughPopupFrame(
             }
             if (acceptsQuestions) {
                 WalkthroughQuestionInput(
-                    isLoading = isLoading,
+                    status = questionStatus,
                     palette = palette,
                     onSubmit = onSubmitQuestion
                 )

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupWidgets.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupWidgets.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -70,9 +71,12 @@ private object WalkthroughWidgetStyle {
     val questionFieldRadius = 18.dp
     val questionFieldPaddingHorizontal = 14.dp
     val questionFieldTextSize = 13.sp
+    val questionStatusSpacing = 4.dp
+    val questionStatusTextSize = 12.sp
     const val QUESTION_FIELD_BACKGROUND_ALPHA = 0.12f
     const val QUESTION_FIELD_BORDER_ALPHA = 0.2f
     const val QUESTION_PLACEHOLDER_ALPHA = 0.55f
+    const val QUESTION_STATUS_ALPHA = 0.72f
     val sendButtonSize = 34.dp
     val spinnerSize = 18.dp
     val spinnerStrokeWidth = 2.dp
@@ -234,42 +238,52 @@ internal fun AiNavButton(
 
 @Composable
 internal fun WalkthroughQuestionInput(
-    isLoading: Boolean,
+    status: WalkthroughQuestionStatus,
     palette: WalkthroughPalette,
     onSubmit: (String) -> Unit
 ) {
     var text by remember { mutableStateOf("") }
-    val canSubmit = !isLoading && text.isNotBlank()
+    val canType = status == WalkthroughQuestionStatus.AgentNotWaiting ||
+        status == WalkthroughQuestionStatus.WaitingForQuestion
+    val canSubmit = canType && text.isNotBlank()
     val submit: () -> Unit = {
         if (canSubmit) {
             onSubmit(text)
             text = ""
         }
     }
-    Row(
+    Column(
         modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(WalkthroughWidgetStyle.questionRowSpacing),
-        verticalAlignment = Alignment.CenterVertically
+        verticalArrangement = Arrangement.spacedBy(WalkthroughWidgetStyle.questionStatusSpacing)
     ) {
-        QuestionTextField(
-            text = text,
-            isLoading = isLoading,
-            onTextChange = { value -> text = value },
-            onSend = submit,
-            modifier = Modifier.weight(1f)
-        )
-        if (isLoading) {
-            QuestionSpinner(palette = palette)
-        } else {
-            SendQuestionButton(enabled = canSubmit, palette = palette, onClick = submit)
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(WalkthroughWidgetStyle.questionRowSpacing),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            QuestionTextField(
+                text = text,
+                enabled = canType,
+                placeholder = questionPlaceholder(status),
+                onTextChange = { value -> text = value },
+                onSend = submit,
+                modifier = Modifier.weight(1f)
+            )
+            if (status == WalkthroughQuestionStatus.ProcessingQuestion) {
+                QuestionSpinner(palette = palette)
+            } else {
+                SendQuestionButton(enabled = canSubmit, palette = palette, onClick = submit)
+            }
         }
+        QuestionStatusText(status = status)
     }
 }
 
 @Composable
 private fun QuestionTextField(
     text: String,
-    isLoading: Boolean,
+    enabled: Boolean,
+    placeholder: String,
     onTextChange: (String) -> Unit,
     onSend: () -> Unit,
     modifier: Modifier = Modifier
@@ -293,7 +307,7 @@ private fun QuestionTextField(
         BasicTextField(
             value = text,
             onValueChange = onTextChange,
-            enabled = !isLoading,
+            enabled = enabled,
             singleLine = true,
             textStyle = TextStyle(
                 color = Color.White,
@@ -307,7 +321,7 @@ private fun QuestionTextField(
             decorationBox = { innerTextField ->
                 if (text.isEmpty()) {
                     Text(
-                        text = "Ask a question about this step…",
+                        text = placeholder,
                         color = Color.White.copy(alpha = WalkthroughWidgetStyle.QUESTION_PLACEHOLDER_ALPHA),
                         fontSize = WalkthroughWidgetStyle.questionFieldTextSize
                     )
@@ -317,6 +331,31 @@ private fun QuestionTextField(
         )
     }
 }
+
+@Composable
+private fun QuestionStatusText(status: WalkthroughQuestionStatus) {
+    Text(
+        text = questionStatusText(status),
+        color = Color.White.copy(alpha = WalkthroughWidgetStyle.QUESTION_STATUS_ALPHA),
+        fontSize = WalkthroughWidgetStyle.questionStatusTextSize
+    )
+}
+
+private fun questionPlaceholder(status: WalkthroughQuestionStatus): String =
+    when (status) {
+        WalkthroughQuestionStatus.AgentNotWaiting,
+        WalkthroughQuestionStatus.WaitingForQuestion -> "Ask a question about this step…"
+        WalkthroughQuestionStatus.QuestionQueued -> "Question queued"
+        WalkthroughQuestionStatus.ProcessingQuestion -> "Question sent"
+    }
+
+private fun questionStatusText(status: WalkthroughQuestionStatus): String =
+    when (status) {
+        WalkthroughQuestionStatus.AgentNotWaiting -> "await_walkthrough_question is not running."
+        WalkthroughQuestionStatus.WaitingForQuestion -> "await_walkthrough_question is listening for questions."
+        WalkthroughQuestionStatus.QuestionQueued -> "Question is ready; await_walkthrough_question is not running."
+        WalkthroughQuestionStatus.ProcessingQuestion -> "Question is being processed by the agent."
+    }
 
 @Composable
 private fun SendQuestionButton(enabled: Boolean, palette: WalkthroughPalette, onClick: () -> Unit) {

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupWidgets.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupWidgets.kt
@@ -334,8 +334,9 @@ private fun QuestionTextField(
 
 @Composable
 private fun QuestionStatusText(status: WalkthroughQuestionStatus) {
+    val text = questionStatusText(status) ?: return
     Text(
-        text = questionStatusText(status),
+        text = text,
         color = Color.White.copy(alpha = WalkthroughWidgetStyle.QUESTION_STATUS_ALPHA),
         fontSize = WalkthroughWidgetStyle.questionStatusTextSize
     )
@@ -349,12 +350,13 @@ private fun questionPlaceholder(status: WalkthroughQuestionStatus): String =
         WalkthroughQuestionStatus.ProcessingQuestion -> "Question sent"
     }
 
-private fun questionStatusText(status: WalkthroughQuestionStatus): String =
+private fun questionStatusText(status: WalkthroughQuestionStatus): String? =
     when (status) {
-        WalkthroughQuestionStatus.AgentNotWaiting -> "await_walkthrough_question is not running."
-        WalkthroughQuestionStatus.WaitingForQuestion -> "await_walkthrough_question is listening for questions."
-        WalkthroughQuestionStatus.QuestionQueued -> "Question is ready; await_walkthrough_question is not running."
-        WalkthroughQuestionStatus.ProcessingQuestion -> "Question is being processed by the agent."
+        WalkthroughQuestionStatus.AgentNotWaiting,
+        WalkthroughQuestionStatus.QuestionQueued ->
+            "⚠\uFE0F Agent is not listening, it should call await_walkthrough_question"
+        WalkthroughQuestionStatus.WaitingForQuestion,
+        WalkthroughQuestionStatus.ProcessingQuestion -> null
     }
 
 @Composable

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughSessionRegistry.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughSessionRegistry.kt
@@ -7,7 +7,9 @@ import androidx.compose.runtime.snapshots.SnapshotStateList
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.project.Project
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedQueue
@@ -16,6 +18,30 @@ import java.util.concurrent.atomic.AtomicReference
 data class WalkthroughTangentQuestion(
     val question: String,
     val parentLabel: String?
+)
+
+internal enum class WalkthroughQuestionStatus {
+    AgentNotWaiting,
+    WaitingForQuestion,
+    QuestionQueued,
+    ProcessingQuestion
+}
+
+internal sealed interface WalkthroughQuestionAwaitResult {
+    data class Received(val question: WalkthroughTangentQuestion) : WalkthroughQuestionAwaitResult
+    data object Dismissed : WalkthroughQuestionAwaitResult
+    data object WaitingExpired : WalkthroughQuestionAwaitResult
+    data object Replaced : WalkthroughQuestionAwaitResult
+}
+
+private class WalkthroughQuestionWaiter {
+    val result = CompletableDeferred<WalkthroughQuestionAwaitResult>()
+}
+
+private data class WalkthroughQuestionWaitRegistration(
+    val waiter: WalkthroughQuestionWaiter?,
+    val previousWaiter: WalkthroughQuestionWaiter?,
+    val immediateResult: WalkthroughQuestionAwaitResult?
 )
 
 class WalkthroughSession internal constructor(
@@ -28,9 +54,13 @@ class WalkthroughSession internal constructor(
     internal val items: SnapshotStateList<WalkthroughItem> =
         mutableStateListOf<WalkthroughItem>().apply { addAll(initialItems) }
     internal val currentIndexState = mutableIntStateOf(0)
+    internal val questionStatusState = mutableStateOf(WalkthroughQuestionStatus.AgentNotWaiting)
     internal val loadingState = mutableStateOf(false)
 
-    private val questionChannel = Channel<WalkthroughTangentQuestion>(capacity = Channel.UNLIMITED)
+    private val questionLock = Any()
+    private var activeQuestionWaiter: WalkthroughQuestionWaiter? = null
+    private var pendingQuestion: WalkthroughTangentQuestion? = null
+    private var inFlightQuestion: WalkthroughTangentQuestion? = null
     private val disposed = CompletableDeferred<Unit>()
 
     fun snapshotItems(): List<WalkthroughItem> = items.toList()
@@ -39,15 +69,54 @@ class WalkthroughSession internal constructor(
         val trimmed = text.trim()
         if (trimmed.isEmpty()) return
         val parentItem = items.getOrNull(currentIndexState.intValue)
-        loadingState.value = true
-        val result = questionChannel.trySend(WalkthroughTangentQuestion(trimmed, parentItem?.label))
-        if (result.isFailure) {
-            loadingState.value = false
+        val question = WalkthroughTangentQuestion(trimmed, parentItem?.label)
+        val waiter = synchronized(questionLock) {
+            when {
+                disposed.isCompleted -> null
+                pendingQuestion != null -> null
+                questionStatusState.value == WalkthroughQuestionStatus.ProcessingQuestion -> null
+                activeQuestionWaiter != null -> {
+                    activeQuestionWaiter.also {
+                        activeQuestionWaiter = null
+                        inFlightQuestion = question
+                        setQuestionStatus(WalkthroughQuestionStatus.ProcessingQuestion)
+                    }
+                }
+                else -> {
+                    pendingQuestion = question
+                    setQuestionStatus(WalkthroughQuestionStatus.QuestionQueued)
+                    null
+                }
+            }
         }
+        waiter?.result?.complete(WalkthroughQuestionAwaitResult.Received(question))
     }
 
     suspend fun awaitQuestion(): WalkthroughTangentQuestion? =
-        questionChannel.receiveCatching().getOrNull()
+        when (val result = awaitQuestionResult(timeoutMillis = null)) {
+            is WalkthroughQuestionAwaitResult.Received -> result.question
+            else -> null
+        }
+
+    internal suspend fun awaitQuestionResult(timeoutMillis: Long?): WalkthroughQuestionAwaitResult = coroutineScope {
+        val registration = registerQuestionWaiter()
+        registration.previousWaiter?.result?.complete(WalkthroughQuestionAwaitResult.Replaced)
+        registration.immediateResult?.let { return@coroutineScope it }
+
+        val waiter = registration.waiter ?: return@coroutineScope WalkthroughQuestionAwaitResult.Dismissed
+        val timeoutJob = timeoutMillis?.let { timeout ->
+            launch {
+                delay(timeout)
+                expireQuestionWaiter(waiter)
+            }
+        }
+        try {
+            waiter.result.await()
+        } finally {
+            timeoutJob?.cancel()
+            clearQuestionWaiter(waiter)
+        }
+    }
 
     fun insertTangents(parentLabel: String, newItems: List<WalkthroughItem>): List<WalkthroughItem> {
         try {
@@ -76,15 +145,96 @@ class WalkthroughSession internal constructor(
             currentIndexState.intValue = lastSubtreeIndex + 1
             return labeled
         } finally {
-            loadingState.value = false
+            synchronized(questionLock) {
+                inFlightQuestion = null
+                setQuestionStatus(WalkthroughQuestionStatus.AgentNotWaiting)
+            }
         }
     }
 
     internal fun dismiss() {
         if (disposed.complete(Unit)) {
-            loadingState.value = false
-            questionChannel.close()
+            val waiter = synchronized(questionLock) {
+                activeQuestionWaiter.also {
+                    activeQuestionWaiter = null
+                    pendingQuestion = null
+                    inFlightQuestion = null
+                    setQuestionStatus(WalkthroughQuestionStatus.AgentNotWaiting)
+                }
+            }
+            waiter?.result?.complete(WalkthroughQuestionAwaitResult.Dismissed)
         }
+    }
+
+    private fun registerQuestionWaiter(): WalkthroughQuestionWaitRegistration {
+        val waiter = WalkthroughQuestionWaiter()
+        return synchronized(questionLock) {
+            when {
+                disposed.isCompleted -> WalkthroughQuestionWaitRegistration(
+                    waiter = null,
+                    previousWaiter = null,
+                    immediateResult = WalkthroughQuestionAwaitResult.Dismissed
+                )
+                inFlightQuestion != null -> {
+                    setQuestionStatus(WalkthroughQuestionStatus.ProcessingQuestion)
+                    WalkthroughQuestionWaitRegistration(
+                        waiter = null,
+                        previousWaiter = null,
+                        immediateResult = WalkthroughQuestionAwaitResult.Received(requireNotNull(inFlightQuestion))
+                    )
+                }
+                pendingQuestion != null -> {
+                    val question = pendingQuestion
+                    pendingQuestion = null
+                    inFlightQuestion = question
+                    setQuestionStatus(WalkthroughQuestionStatus.ProcessingQuestion)
+                    WalkthroughQuestionWaitRegistration(
+                        waiter = null,
+                        previousWaiter = null,
+                        immediateResult = WalkthroughQuestionAwaitResult.Received(requireNotNull(question))
+                    )
+                }
+                else -> {
+                    val previousWaiter = activeQuestionWaiter
+                    activeQuestionWaiter = waiter
+                    setQuestionStatus(WalkthroughQuestionStatus.WaitingForQuestion)
+                    WalkthroughQuestionWaitRegistration(
+                        waiter = waiter,
+                        previousWaiter = previousWaiter,
+                        immediateResult = null
+                    )
+                }
+            }
+        }
+    }
+
+    private fun expireQuestionWaiter(waiter: WalkthroughQuestionWaiter) {
+        val expired = synchronized(questionLock) {
+            if (activeQuestionWaiter === waiter) {
+                activeQuestionWaiter = null
+                setQuestionStatus(WalkthroughQuestionStatus.AgentNotWaiting)
+                true
+            } else {
+                false
+            }
+        }
+        if (expired) {
+            waiter.result.complete(WalkthroughQuestionAwaitResult.WaitingExpired)
+        }
+    }
+
+    private fun clearQuestionWaiter(waiter: WalkthroughQuestionWaiter) {
+        synchronized(questionLock) {
+            if (activeQuestionWaiter === waiter) {
+                activeQuestionWaiter = null
+                setQuestionStatus(WalkthroughQuestionStatus.AgentNotWaiting)
+            }
+        }
+    }
+
+    private fun setQuestionStatus(status: WalkthroughQuestionStatus) {
+        questionStatusState.value = status
+        loadingState.value = status == WalkthroughQuestionStatus.ProcessingQuestion
     }
 }
 

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughSessionRegistry.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughSessionRegistry.kt
@@ -119,37 +119,34 @@ class WalkthroughSession internal constructor(
     }
 
     fun insertTangents(parentLabel: String, newItems: List<WalkthroughItem>): List<WalkthroughItem> {
-        try {
-            require(newItems.isNotEmpty()) { "newItems must not be empty" }
-            val parentIndex = items.indexOfFirst { it.label == parentLabel }
-            require(parentIndex >= 0) { "No item with label '$parentLabel'" }
+        require(newItems.isNotEmpty()) { "newItems must not be empty" }
+        val parentIndex = items.indexOfFirst { it.label == parentLabel }
+        require(parentIndex >= 0) { "No item with label '$parentLabel'" }
 
-            val directChildPattern = Regex("^${Regex.escape(parentLabel)}\\.\\d+$")
-            val existingDirectChildren = items.count { it.label?.matches(directChildPattern) == true }
+        val directChildPattern = Regex("^${Regex.escape(parentLabel)}\\.\\d+$")
+        val existingDirectChildren = items.count { it.label?.matches(directChildPattern) == true }
 
-            val parentPrefix = "$parentLabel."
-            var lastSubtreeIndex = parentIndex
-            items.forEachIndexed { index, item ->
-                if (item.label?.startsWith(parentPrefix) == true) {
-                    lastSubtreeIndex = index
-                }
-            }
-
-            val labeled = newItems.mapIndexed { offset, item ->
-                item.copy(
-                    label = "$parentLabel.${existingDirectChildren + offset + 1}",
-                    parentLabel = parentLabel
-                )
-            }
-            items.addAll(lastSubtreeIndex + 1, labeled)
-            currentIndexState.intValue = lastSubtreeIndex + 1
-            return labeled
-        } finally {
-            synchronized(questionLock) {
-                inFlightQuestion = null
-                setQuestionStatus(WalkthroughQuestionStatus.AgentNotWaiting)
+        val parentPrefix = "$parentLabel."
+        var lastSubtreeIndex = parentIndex
+        items.forEachIndexed { index, item ->
+            if (item.label?.startsWith(parentPrefix) == true) {
+                lastSubtreeIndex = index
             }
         }
+
+        val labeled = newItems.mapIndexed { offset, item ->
+            item.copy(
+                label = "$parentLabel.${existingDirectChildren + offset + 1}",
+                parentLabel = parentLabel
+            )
+        }
+        items.addAll(lastSubtreeIndex + 1, labeled)
+        currentIndexState.intValue = lastSubtreeIndex + 1
+        synchronized(questionLock) {
+            inFlightQuestion = null
+            setQuestionStatus(WalkthroughQuestionStatus.AgentNotWaiting)
+        }
+        return labeled
     }
 
     internal fun dismiss() {

--- a/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughSessionRegistryTest.kt
+++ b/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughSessionRegistryTest.kt
@@ -108,18 +108,26 @@ class WalkthroughSessionRegistryTest {
     }
 
     @Test
-    fun insertTangentsClearsLoadingAfterValidationFailure() {
+    fun insertTangentsPreservesInFlightQuestionAfterValidationFailure() = runBlocking {
         val session = newSession(
             assignTopLevelLabels(listOf(WalkthroughItem(text = "only")))
         )
-        session.loadingState.value = true
+        session.submitQuestion("can you explain?")
+        val firstResult = session.awaitQuestionResult(timeoutMillis = TEST_AWAIT_TIMEOUT_MILLIS)
 
         assertThrows(IllegalArgumentException::class.java) {
             session.insertTangents("9", listOf(WalkthroughItem(text = "x")))
         }
 
-        assertEquals(false, session.loadingState.value)
-        assertEquals(WalkthroughQuestionStatus.AgentNotWaiting, session.questionStatusState.value)
+        assertTrue(firstResult is WalkthroughQuestionAwaitResult.Received)
+        assertEquals(WalkthroughQuestionStatus.ProcessingQuestion, session.questionStatusState.value)
+        assertEquals(true, session.loadingState.value)
+
+        val retryResult = session.awaitQuestionResult(timeoutMillis = TEST_AWAIT_TIMEOUT_MILLIS)
+
+        assertTrue(retryResult is WalkthroughQuestionAwaitResult.Received)
+        val retryQuestion = (retryResult as WalkthroughQuestionAwaitResult.Received).question
+        assertEquals("can you explain?", retryQuestion.question)
     }
 
     @Test

--- a/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughSessionRegistryTest.kt
+++ b/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughSessionRegistryTest.kt
@@ -1,11 +1,14 @@
 package com.forketyfork.walkthrough
 
 import com.intellij.openapi.Disposable
+import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.yield
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 
@@ -116,6 +119,7 @@ class WalkthroughSessionRegistryTest {
         }
 
         assertEquals(false, session.loadingState.value)
+        assertEquals(WalkthroughQuestionStatus.AgentNotWaiting, session.questionStatusState.value)
     }
 
     @Test
@@ -144,6 +148,8 @@ class WalkthroughSessionRegistryTest {
         assertNotNull(question)
         assertEquals("2", question?.parentLabel)
         assertEquals("what about two?", question?.question)
+        assertEquals(WalkthroughQuestionStatus.ProcessingQuestion, session.questionStatusState.value)
+        assertEquals(true, session.loadingState.value)
     }
 
     @Test
@@ -156,6 +162,91 @@ class WalkthroughSessionRegistryTest {
         session.submitQuestion("what now?")
 
         assertEquals(false, session.loadingState.value)
+        assertEquals(WalkthroughQuestionStatus.AgentNotWaiting, session.questionStatusState.value)
+    }
+
+    @Test
+    fun submitQuestionQueuesWhenAgentIsNotWaiting() {
+        val session = newSession(
+            assignTopLevelLabels(listOf(WalkthroughItem(text = "only")))
+        )
+
+        session.submitQuestion("can you explain?")
+
+        assertEquals(WalkthroughQuestionStatus.QuestionQueued, session.questionStatusState.value)
+        assertEquals(false, session.loadingState.value)
+    }
+
+    @Test
+    fun queuedQuestionIsDeliveredToNextAwait() = runBlocking {
+        val session = newSession(
+            assignTopLevelLabels(listOf(WalkthroughItem(text = "only")))
+        )
+        session.submitQuestion("can you explain?")
+
+        val result = session.awaitQuestionResult(timeoutMillis = TEST_AWAIT_TIMEOUT_MILLIS)
+
+        assertTrue(result is WalkthroughQuestionAwaitResult.Received)
+        val question = (result as WalkthroughQuestionAwaitResult.Received).question
+        assertEquals("can you explain?", question.question)
+        assertEquals("1", question.parentLabel)
+        assertEquals(WalkthroughQuestionStatus.ProcessingQuestion, session.questionStatusState.value)
+        assertEquals(true, session.loadingState.value)
+    }
+
+    @Test
+    fun inFlightQuestionCanBeClaimedAgainUntilTangentsAreInserted() = runBlocking {
+        val session = newSession(
+            assignTopLevelLabels(listOf(WalkthroughItem(text = "only")))
+        )
+        session.submitQuestion("can you explain?")
+
+        val firstResult = session.awaitQuestionResult(timeoutMillis = TEST_AWAIT_TIMEOUT_MILLIS)
+        val secondResult = session.awaitQuestionResult(timeoutMillis = TEST_AWAIT_TIMEOUT_MILLIS)
+
+        assertTrue(firstResult is WalkthroughQuestionAwaitResult.Received)
+        assertTrue(secondResult is WalkthroughQuestionAwaitResult.Received)
+        val firstQuestion = (firstResult as WalkthroughQuestionAwaitResult.Received).question
+        val secondQuestion = (secondResult as WalkthroughQuestionAwaitResult.Received).question
+        assertEquals(firstQuestion, secondQuestion)
+
+        session.insertTangents("1", listOf(WalkthroughItem(text = "answer")))
+        val resultAfterAnswer = session.awaitQuestionResult(timeoutMillis = 1L)
+
+        assertSame(WalkthroughQuestionAwaitResult.WaitingExpired, resultAfterAnswer)
+    }
+
+    @Test
+    fun awaitQuestionResultExpiresAndMarksAgentNotWaiting() = runBlocking {
+        val session = newSession(
+            assignTopLevelLabels(listOf(WalkthroughItem(text = "only")))
+        )
+
+        val result = session.awaitQuestionResult(timeoutMillis = 1L)
+
+        assertSame(WalkthroughQuestionAwaitResult.WaitingExpired, result)
+        assertEquals(WalkthroughQuestionStatus.AgentNotWaiting, session.questionStatusState.value)
+        assertEquals(false, session.loadingState.value)
+    }
+
+    @Test
+    fun newAwaitReplacesPreviousWaiter() = runBlocking {
+        val session = newSession(
+            assignTopLevelLabels(listOf(WalkthroughItem(text = "only")))
+        )
+        val firstAwait = async { session.awaitQuestionResult(timeoutMillis = TEST_AWAIT_TIMEOUT_MILLIS) }
+        waitUntilQuestionStatus(session, WalkthroughQuestionStatus.WaitingForQuestion)
+
+        val secondAwait = async { session.awaitQuestionResult(timeoutMillis = TEST_AWAIT_TIMEOUT_MILLIS) }
+        assertSame(WalkthroughQuestionAwaitResult.Replaced, firstAwait.await())
+        waitUntilQuestionStatus(session, WalkthroughQuestionStatus.WaitingForQuestion)
+
+        session.submitQuestion("fresh question")
+        val result = secondAwait.await()
+
+        assertTrue(result is WalkthroughQuestionAwaitResult.Received)
+        val question = (result as WalkthroughQuestionAwaitResult.Received).question
+        assertEquals("fresh question", question.question)
     }
 
     @Test
@@ -196,5 +287,21 @@ class WalkthroughSessionRegistryTest {
         assertNull(registry.get(session.id))
         assertEquals(true, registry.consumeDismissed(session.id))
         assertEquals(false, registry.consumeDismissed(session.id))
+    }
+
+    private suspend fun waitUntilQuestionStatus(
+        session: WalkthroughSession,
+        status: WalkthroughQuestionStatus
+    ) {
+        repeat(TEST_STATUS_WAIT_ATTEMPTS) {
+            if (session.questionStatusState.value == status) return
+            yield()
+        }
+        assertEquals(status, session.questionStatusState.value)
+    }
+
+    private companion object {
+        const val TEST_AWAIT_TIMEOUT_MILLIS = 1_000L
+        const val TEST_STATUS_WAIT_ATTEMPTS = 100
     }
 }


### PR DESCRIPTION
## Solution

Codex can abandon long-running tool calls after 120 seconds. The question popup used a single loading flag tied to sending a question and receiving answer steps, so once the wait call disappeared the user only saw a spinner. A later `await_walkthrough_question` call also did not reliably reconnect to the question that was already asked.

This PR gives the walkthrough session explicit question states: `await_walkthrough_question` listening, no active waiter, queued question, and processing. The await tool now returns `waiting-expired` after 110 seconds so Codex can call it again before its own timeout. Submitted questions stay pending or in flight until tangent answer steps are inserted, which lets a retry recover the same question instead of waiting for another one.

The popup status text now names `await_walkthrough_question` directly, so the user can tell whether the agent is listening, processing the question, or not running the wait tool.

No issue linked; linkage will be added during mandatory cleanup.

## Verification

- `./gradlew test --tests com.forketyfork.walkthrough.WalkthroughSessionRegistryTest`
- `just lint`
- `just build`

## Test plan

- [ ] Start a sandbox IDE, show a walkthrough, and confirm the popup names `await_walkthrough_question` in its status text.
- [ ] Ask a question while no wait call is active, then call `await_walkthrough_question` and confirm the queued question is delivered.
- [ ] Insert tangent answer steps and confirm the spinner clears and the question input is usable again.
