### PR TITLE
Add commit-backed diff walkthroughs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,6 +51,7 @@ dependencies {
         bundledModule("intellij.platform.jewel.markdown.extensions.gfmTables")
         bundledModule("intellij.platform.jewel.markdown.extensions.gfmStrikethrough")
         bundledPlugin("com.intellij.mcpServer")
+        bundledPlugin("Git4Idea")
 
     }
 }

--- a/docs/superpowers/specs/2026-05-20-diff-walkthroughs-design.md
+++ b/docs/superpowers/specs/2026-05-20-diff-walkthroughs-design.md
@@ -24,9 +24,6 @@ Relevant public API:
 - `DiffManager.getInstance().showDiff(project, request)` opens a diff request.
 - `DiffRequestFactory.getInstance().createFromFiles(project, left, right)`
   creates file-backed diff requests.
-- `DiffContentFactory.getInstance().create(project, text, highlightFile)` and
-  `SimpleDiffRequest` can create text-backed diffs when the agent supplies both
-  sides.
 - `DiffUserDataKeys.SCROLL_TO_LINE` can request initial scrolling to a side and
   line.
 - `DiffExtension.onViewerCreated(viewer, context, request)` can customize
@@ -35,6 +32,9 @@ Relevant public API:
   viewers.
 - Diff tabs opened as file editors can also expose embedded editors via
   `FileEditorWithTextEditors.getEmbeddedEditors()`.
+- With a `Git4Idea` bundled plugin dependency, `GitContentRevision` can resolve
+  a project file at a specific Git commit hash, and the VCS `Change`/diff
+  request machinery can render a standard IDEA diff from those revisions.
 
 This means a diff walkthrough can be implemented without replacing the existing
 Compose popup. The main change is target resolution: instead of resolving a
@@ -61,6 +61,7 @@ data class WalkthroughItem(
     val text: String,
     val file: String? = null,
     val line: Int? = null,
+    val diffId: String? = null,
     val diffFile: String? = null,
     val diffSide: DiffSide? = null,
     val label: String? = null,
@@ -74,28 +75,30 @@ enum class DiffSide {
 ```
 
 The current `file` and `line` fields stay file-mode fields. Diff-mode items use
-`diffFile`, `diffSide`, and `line`. The line is 1-based in the chosen side's
-full file text, not a patch hunk line.
+`diffId`, `diffFile`, `diffSide`, and `line`. The line is 1-based in the chosen
+side's full file text at that commit, not a patch hunk line. Commit hashes live
+on the diff descriptor, not duplicated into every item.
 
 ### Diff content source
 
-Start with text-backed diffs prepared by the agent:
+Use commit-backed diffs. The agent should not submit file text. It should
+submit the commit hashes that identify the two file revisions to compare.
 
 ```json
 {
   "kind": "diff",
   "diffs": [
     {
+      "id": "foo-main-to-pr",
       "file": "src/Foo.kt",
-      "leftTitle": "base",
-      "rightTitle": "working tree",
-      "leftText": "...",
-      "rightText": "..."
+      "leftCommit": "1a2b3c4d5e6f...",
+      "rightCommit": "9f8e7d6c5b4a..."
     }
   ],
   "items": [
     {
       "text": "This new branch handles the null result.",
+      "diffId": "foo-main-to-pr",
       "diffFile": "src/Foo.kt",
       "diffSide": "right",
       "line": 42
@@ -104,45 +107,83 @@ Start with text-backed diffs prepared by the agent:
 }
 ```
 
-Reasons:
+Reasons for this contract:
 
-- It keeps the plugin independent of Git, GitHub, and PR provider APIs.
-- It lets agents review arbitrary diffs, including uncommitted changes, branch
-  comparisons, copied patches, and PR context obtained through MCP.
-- It makes line-number verification explicit: the agent must verify the line in
-  the side text it submits.
+- It keeps large file contents out of MCP tool arguments and history records.
+- It lets IDEA render a native VCS diff and load contents through the platform's
+  Git revision cache.
+- It makes PR walkthroughs precise: the agent can compare a file at the merge
+  base to the same file at the PR head.
+- It makes history replay feasible as long as the commits remain available in
+  the local repository.
 
-Later, add a VCS-backed mode if needed:
+For a PR walkthrough, the agent should determine the merge-base commit and the
+PR head commit, ensure both commits are available locally, and pass those hashes
+for every file diff it wants to annotate. For a single commit walkthrough, the
+agent should compare the parent commit to the commit being explained. For a
+branch walkthrough, compare the merge base of the target branch and topic branch
+to the topic branch head.
+
+The first implementation should require full commit hashes or refs that Git can
+resolve locally. Full hashes are preferred because they are stable for history
+replay. The plugin can optionally resolve refs to full hashes before saving the
+record.
+
+Support renamed files by allowing separate left/right paths:
 
 ```json
 {
   "kind": "diff",
-  "source": {
-    "type": "git",
-    "baseRef": "main",
-    "headRef": "HEAD"
-  },
+  "diffs": [
+    {
+      "id": "foo-rename",
+      "leftFile": "src/OldFoo.kt",
+      "rightFile": "src/Foo.kt",
+      "leftCommit": "1a2b3c4d5e6f...",
+      "rightCommit": "9f8e7d6c5b4a..."
+    }
+  ],
   "items": [...]
 }
 ```
 
-That second mode is more native, but it couples the plugin to VCS APIs and makes
-non-Git/remote-review workflows harder.
+In the common non-rename case, `file` is shorthand for both `leftFile` and
+`rightFile`. `id` should be unique within the walkthrough payload. It prevents
+ambiguity if the same file is shown across more than one commit pair.
+
+This does couple diff walkthroughs to Git. That is acceptable for this feature
+because the requested workflow is PR/change review by commit hash. The plugin
+will need `bundledPlugin("Git4Idea")` in Gradle and `<depends
+optional="true|false">Git4Idea</depends>` in `plugin.xml`. Make the dependency
+non-optional if diff walkthroughs are a core advertised feature; make it
+optional only if the tool is registered conditionally or fails with a clear
+"Git plugin unavailable" error.
 
 ### Opening and anchoring
 
 For each diff item:
 
-1. Find the matching submitted diff by `diffFile`.
-2. Create left and right `DocumentContent` with `DiffContentFactory`.
-3. Use `SimpleDiffRequest` with content titles.
-4. Put `DiffUserDataKeys.SCROLL_TO_LINE` on the request using the requested
+1. Find the matching diff descriptor by `diffId`, falling back to `diffFile`
+   only if the payload has a single descriptor for that file.
+2. Resolve the project Git root for the left/right file paths.
+3. Build `FilePath` instances for `leftFile` and `rightFile`.
+4. Build `GitRevisionNumber(leftCommit)` and `GitRevisionNumber(rightCommit)`.
+   Optionally call `GitRevisionNumber.resolve(project, root, ref)` first to
+   normalize refs and short hashes to full hashes.
+5. Build `GitContentRevision.createRevision(filePath, revisionNumber, project)`
+   for each side.
+6. Build a VCS `Change(leftRevision, rightRevision)`.
+7. Create a `ChangeDiffRequestProducer` or directly create equivalent
+   `DiffContent` instances from the revisions. Prefer the platform producer if
+   it gives better VCS metadata and title handling without relying on internal
+   APIs.
+8. Put `DiffUserDataKeys.SCROLL_TO_LINE` on the request using the requested
    side and zero-based line.
-5. Add plugin-specific user data to the request containing the walkthrough
+9. Add plugin-specific user data to the request containing the walkthrough
    session id and target item.
-6. Call `DiffManager.getInstance().showDiff(project, request)` on the EDT.
-7. Use a `DiffExtension` to detect tagged requests in `onViewerCreated`.
-8. If the viewer is an `EditorDiffViewer`, choose the editor by side from
+10. Call `DiffManager.getInstance().showDiff(project, request)` on the EDT.
+11. Use a `DiffExtension` to detect tagged requests in `onViewerCreated`.
+12. If the viewer is an `EditorDiffViewer`, choose the editor by side from
    `getEditors()`, move its caret to the requested line, and attach
    `WalkthroughPopupSurface` to that editor.
 
@@ -150,14 +191,19 @@ The existing `WalkthroughPopupSurface` can remain editor-based. Diff editors are
 normal editor instances for anchoring, scrolling listeners, and line-to-screen
 coordinate calculations.
 
+Never call `ContentRevision.getContent()` or `getContentAsBytes()` on the EDT.
+Git revision content loading can hit Git and the platform cache. Prepare the
+diff request under background/progress-aware work, then switch to the EDT to
+show the diff and attach the popup.
+
 ### Navigation behavior
 
 When the user clicks Previous or Next:
 
-- If the next diff item references the same `diffFile`, keep the current diff
-  open and move the popup to the requested side and line.
-- If the next item references a different `diffFile`, open that diff and attach
-  after the viewer is created.
+- If the next diff item references the same diff descriptor, keep the current
+  diff open and move the popup to the requested side and line.
+- If the next item references a different file or a different commit pair, open
+  that diff and attach after the viewer is created.
 
 If the user switches away from the diff tab, hide the connector using the same
 principle already used for file editor changes.
@@ -166,15 +212,15 @@ principle already used for file editor changes.
 
 Persist `kind`, diff descriptors, and item-side fields in history.
 
-For text-backed diffs, storing full left/right texts can make history large. A
-reasonable first implementation is:
+For commit-backed diffs, history should persist:
 
-- Persist diff walkthrough metadata and items.
-- Do not persist full diff contents unless needed for replay.
-- Mark replay unavailable if the stored diff contents are absent.
+- `leftCommit` and `rightCommit`.
+- `leftFile` and `rightFile`, or `file` when paths are unchanged.
+- the descriptor `id`.
+- item anchors: `diffId`, `diffFile`, `diffSide`, and `line`.
 
-If replay is important from day one, persist the texts but cap record size and
-fail gracefully when a diff is too large.
+Replay should fail gracefully when the repository no longer has one of the
+commits. The failure message should name the missing commit and file.
 
 ## MCP Tool Shape
 
@@ -220,18 +266,22 @@ Suggested `show_diff_walkthrough_items` description:
 > the user asks about changes, a PR, a review, a commit, a branch comparison, a
 > patch, or "what changed". Do not use this for general code explanation unless
 > the user specifically wants the explanation in terms of a change. All items in
-> one call must target submitted diffs; do not mix file walkthrough items and
-> diff walkthrough items.
+> one call must target Git commit-backed file diffs; do not mix file walkthrough
+> items and diff walkthrough items. Do not submit file contents. Submit commit
+> hashes for the two file revisions to compare.
 
 Suggested diff payload parameter description:
 
-> JSON object with `diffs` and `items`. `diffs` supplies the text to compare:
-> `file`, `leftTitle`, `rightTitle`, `leftText`, `rightText`. `items` is an
-> array of walkthrough items with `text`, `diffFile`, `diffSide`, and `line`.
-> `diffSide` is `left` or `right`. `line` is 1-based in that side's full text,
-> not the patch hunk line. Use `right` for added or modified new code, `left` for
-> removed old code, and `right` for unchanged context unless discussing the old
-> version. Verify every line against the side text before calling.
+> JSON object with `diffs` and `items`. `diffs` supplies Git revisions to
+> compare: `id`, `file`, `leftCommit`, and `rightCommit`; for renames, use
+> `leftFile` and `rightFile` instead of `file`. `items` is an array of
+> walkthrough items with `text`, `diffId`, `diffFile`, `diffSide`, and `line`.
+> `diffSide` is `left` or `right`. `line` is 1-based in that side's full file
+> text at that commit, not the patch hunk line. Use `right` for added or modified
+> new code, `left` for removed old code, and `right` for unchanged context unless
+> discussing the old version. Verify every line by inspecting that exact file at
+> that exact commit before calling. For PRs, pass the merge-base commit as
+> `leftCommit` and the PR head commit as `rightCommit`.
 
 ## Companion Skill Guidance
 
@@ -269,17 +319,38 @@ File walkthrough lines are 1-based lines in the current full file.
 
 Diff walkthrough lines are 1-based lines in the selected diff side's full text:
 `right` for added/new code, `left` for deleted/old code. Do not use patch hunk
-line numbers. Read or generate the exact side text first, then verify the
+line numbers. Inspect the exact file at the exact commit first, then verify the
 anchor line before calling the tool.
+```
+
+Add a commit-selection section:
+
+```markdown
+## Diff Commits
+
+For diff walkthroughs, submit commit hashes, not file text.
+
+For PR walkthroughs:
+- Fetch the PR branch and target branch if needed.
+- Resolve the merge base between the target branch and PR head.
+- Use the merge-base commit as `leftCommit`.
+- Use the PR head commit as `rightCommit`.
+- For every walkthrough item, verify the anchor line in the selected side at
+  that commit.
+
+For single-commit walkthroughs, use the first parent as `leftCommit` and the
+commit as `rightCommit`. For branch walkthroughs, use the merge base with the
+target branch as `leftCommit` and the branch head as `rightCommit`.
 ```
 
 ## Open Questions
 
-- Should diff history replay persist full diff texts, or should diff sessions be
-  intentionally non-replayable unless backed by VCS refs?
 - Should the first implementation force side-by-side diffs for stable side
   anchoring, or support unified diffs by mapping item anchors to the unified
   synthetic editor?
 - Should there be a separate `show_diff_walkthrough_items` tool, or a single
   `show_walkthrough_items` tool with a `kind` payload? Separate tools are easier
   for agents to choose correctly and preserve backward compatibility.
+- Should the tool accept short hashes and refs, or require full hashes? Full
+  hashes are better for persistence; accepting refs is more ergonomic but should
+  resolve them to full hashes before history is saved.

--- a/docs/superpowers/specs/2026-05-20-diff-walkthroughs-design.md
+++ b/docs/superpowers/specs/2026-05-20-diff-walkthroughs-design.md
@@ -1,0 +1,285 @@
+# Diff Walkthroughs Design
+
+## Goal
+
+Support walkthroughs anchored to IntelliJ IDEA diff viewers in addition to
+walkthroughs anchored to normal file editors.
+
+Each walkthrough session should have exactly one target kind:
+
+- `file`: items point at project files and 1-based file lines.
+- `diff`: items point at one side of an IDEA diff and 1-based lines in that
+  side's full text.
+
+Agents should choose the target kind before preparing items. A request about
+changes, commits, branches, or PR review should normally use a diff walkthrough.
+A request about how existing code works should normally use a file walkthrough.
+
+## Feasibility
+
+Opening a diff view from a plugin is supported by the IntelliJ Platform.
+
+Relevant public API:
+
+- `DiffManager.getInstance().showDiff(project, request)` opens a diff request.
+- `DiffRequestFactory.getInstance().createFromFiles(project, left, right)`
+  creates file-backed diff requests.
+- `DiffContentFactory.getInstance().create(project, text, highlightFile)` and
+  `SimpleDiffRequest` can create text-backed diffs when the agent supplies both
+  sides.
+- `DiffUserDataKeys.SCROLL_TO_LINE` can request initial scrolling to a side and
+  line.
+- `DiffExtension.onViewerCreated(viewer, context, request)` can customize
+  existing diff viewers.
+- `EditorDiffViewer.getEditors()` exposes the editor instances for text diff
+  viewers.
+- Diff tabs opened as file editors can also expose embedded editors via
+  `FileEditorWithTextEditors.getEmbeddedEditors()`.
+
+This means a diff walkthrough can be implemented without replacing the existing
+Compose popup. The main change is target resolution: instead of resolving a
+project file to a selected text editor, resolve a diff item to a diff request,
+open the request, select the correct embedded editor, then pass that editor to
+the same popup surface.
+
+## Recommended Implementation
+
+### Data model
+
+Keep a top-level session target kind so mixed file/diff sessions are rejected.
+Avoid inferring per item.
+
+Suggested model:
+
+```kotlin
+enum class WalkthroughTargetKind {
+    File,
+    Diff
+}
+
+data class WalkthroughItem(
+    val text: String,
+    val file: String? = null,
+    val line: Int? = null,
+    val diffFile: String? = null,
+    val diffSide: DiffSide? = null,
+    val label: String? = null,
+    val parentLabel: String? = null
+)
+
+enum class DiffSide {
+    Left,
+    Right
+}
+```
+
+The current `file` and `line` fields stay file-mode fields. Diff-mode items use
+`diffFile`, `diffSide`, and `line`. The line is 1-based in the chosen side's
+full file text, not a patch hunk line.
+
+### Diff content source
+
+Start with text-backed diffs prepared by the agent:
+
+```json
+{
+  "kind": "diff",
+  "diffs": [
+    {
+      "file": "src/Foo.kt",
+      "leftTitle": "base",
+      "rightTitle": "working tree",
+      "leftText": "...",
+      "rightText": "..."
+    }
+  ],
+  "items": [
+    {
+      "text": "This new branch handles the null result.",
+      "diffFile": "src/Foo.kt",
+      "diffSide": "right",
+      "line": 42
+    }
+  ]
+}
+```
+
+Reasons:
+
+- It keeps the plugin independent of Git, GitHub, and PR provider APIs.
+- It lets agents review arbitrary diffs, including uncommitted changes, branch
+  comparisons, copied patches, and PR context obtained through MCP.
+- It makes line-number verification explicit: the agent must verify the line in
+  the side text it submits.
+
+Later, add a VCS-backed mode if needed:
+
+```json
+{
+  "kind": "diff",
+  "source": {
+    "type": "git",
+    "baseRef": "main",
+    "headRef": "HEAD"
+  },
+  "items": [...]
+}
+```
+
+That second mode is more native, but it couples the plugin to VCS APIs and makes
+non-Git/remote-review workflows harder.
+
+### Opening and anchoring
+
+For each diff item:
+
+1. Find the matching submitted diff by `diffFile`.
+2. Create left and right `DocumentContent` with `DiffContentFactory`.
+3. Use `SimpleDiffRequest` with content titles.
+4. Put `DiffUserDataKeys.SCROLL_TO_LINE` on the request using the requested
+   side and zero-based line.
+5. Add plugin-specific user data to the request containing the walkthrough
+   session id and target item.
+6. Call `DiffManager.getInstance().showDiff(project, request)` on the EDT.
+7. Use a `DiffExtension` to detect tagged requests in `onViewerCreated`.
+8. If the viewer is an `EditorDiffViewer`, choose the editor by side from
+   `getEditors()`, move its caret to the requested line, and attach
+   `WalkthroughPopupSurface` to that editor.
+
+The existing `WalkthroughPopupSurface` can remain editor-based. Diff editors are
+normal editor instances for anchoring, scrolling listeners, and line-to-screen
+coordinate calculations.
+
+### Navigation behavior
+
+When the user clicks Previous or Next:
+
+- If the next diff item references the same `diffFile`, keep the current diff
+  open and move the popup to the requested side and line.
+- If the next item references a different `diffFile`, open that diff and attach
+  after the viewer is created.
+
+If the user switches away from the diff tab, hide the connector using the same
+principle already used for file editor changes.
+
+### History
+
+Persist `kind`, diff descriptors, and item-side fields in history.
+
+For text-backed diffs, storing full left/right texts can make history large. A
+reasonable first implementation is:
+
+- Persist diff walkthrough metadata and items.
+- Do not persist full diff contents unless needed for replay.
+- Mark replay unavailable if the stored diff contents are absent.
+
+If replay is important from day one, persist the texts but cap record size and
+fail gracefully when a diff is too large.
+
+## MCP Tool Shape
+
+Prefer separate show tools. This gives agents a clearer decision point and keeps
+the existing file walkthrough tool backward-compatible:
+
+- `show_walkthrough_items`: file walkthroughs only.
+- `show_diff_walkthrough_items`: diff walkthroughs only.
+
+Keep `await_walkthrough_question` unchanged. For follow-up insertions, either:
+
+- keep `insert_walkthrough_tangents` and parse items according to the stored
+  session kind, or
+- add `insert_diff_walkthrough_tangents` for symmetry and clearer descriptions.
+
+The lower-risk first pass is to keep one insertion tool and make its description
+explicit that item shape depends on the parent walkthrough kind.
+
+### File Tool Description
+
+Suggested `show_walkthrough_items` description:
+
+> Shows a file walkthrough anchored to normal project files. Use this when the
+> user asks how code works, wants an architecture tour, asks for onboarding, or
+> needs an explanation of existing behavior. Do not use this for PR review,
+> branch review, commit review, or "what changed" requests; use
+> `show_diff_walkthrough_items` instead. Every item must refer to the current
+> full file contents, and line numbers must be verified from the actual file.
+
+Suggested file item parameter description:
+
+> JSON array of file walkthrough items:
+> `[{"text":"...","file":"src/Foo.kt","line":10}]`. Each item requires `text`.
+> `file` is project-root-relative. `line` is 1-based in the current full file,
+> not a diff hunk. Verify line numbers by reading the actual file before calling
+> this tool.
+
+### Diff Tool Description
+
+Suggested `show_diff_walkthrough_items` description:
+
+> Shows a diff walkthrough anchored to IntelliJ IDEA diff viewers. Use this when
+> the user asks about changes, a PR, a review, a commit, a branch comparison, a
+> patch, or "what changed". Do not use this for general code explanation unless
+> the user specifically wants the explanation in terms of a change. All items in
+> one call must target submitted diffs; do not mix file walkthrough items and
+> diff walkthrough items.
+
+Suggested diff payload parameter description:
+
+> JSON object with `diffs` and `items`. `diffs` supplies the text to compare:
+> `file`, `leftTitle`, `rightTitle`, `leftText`, `rightText`. `items` is an
+> array of walkthrough items with `text`, `diffFile`, `diffSide`, and `line`.
+> `diffSide` is `left` or `right`. `line` is 1-based in that side's full text,
+> not the patch hunk line. Use `right` for added or modified new code, `left` for
+> removed old code, and `right` for unchanged context unless discussing the old
+> version. Verify every line against the side text before calling.
+
+## Companion Skill Guidance
+
+Add a mode-selection section to the walkthrough skill:
+
+```markdown
+## Choose File vs Diff Mode
+
+Before preparing items, choose exactly one mode.
+
+Use file mode for:
+- explaining how existing code works
+- architecture or onboarding tours
+- tracing runtime behavior
+- debugging a current implementation without focusing on a change set
+
+Use diff mode for:
+- PR review
+- commit, branch, or patch review
+- "what changed?", "review my changes", or "explain this diff"
+- risk analysis, regression analysis, or test recommendations for a change set
+
+Never mix file and diff items in one walkthrough. If the user asks both to
+review changes and explain surrounding architecture, start with a diff
+walkthrough and use follow-up tangent steps for extra context, or ask whether
+they want a separate file walkthrough.
+```
+
+Add a line-number section:
+
+```markdown
+## Line Numbers
+
+File walkthrough lines are 1-based lines in the current full file.
+
+Diff walkthrough lines are 1-based lines in the selected diff side's full text:
+`right` for added/new code, `left` for deleted/old code. Do not use patch hunk
+line numbers. Read or generate the exact side text first, then verify the
+anchor line before calling the tool.
+```
+
+## Open Questions
+
+- Should diff history replay persist full diff texts, or should diff sessions be
+  intentionally non-replayable unless backed by VCS refs?
+- Should the first implementation force side-by-side diffs for stable side
+  anchoring, or support unified diffs by mapping item anchors to the unified
+  synthetic editor?
+- Should there be a separate `show_diff_walkthrough_items` tool, or a single
+  `show_walkthrough_items` tool with a `kind` payload? Separate tools are easier
+  for agents to choose correctly and preserve backward compatibility.

--- a/src/main/kotlin/com/forketyfork/walkthrough/DiffWalkthroughSession.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/DiffWalkthroughSession.kt
@@ -178,8 +178,16 @@ private class DiffWalkthroughController(
     }
 
     fun attachToViewer(viewer: FrameDiffTool.DiffViewer, item: WalkthroughItem) {
-        if (sessionDisposable.isDisposed || viewer !is EditorDiffViewer) return
-        val editor = selectEditor(viewer, item.diffSide ?: DiffSide.Right) ?: return
+        if (!sessionDisposable.isDisposed && viewer is EditorDiffViewer) {
+            val editor = selectEditor(viewer, item.diffSide ?: DiffSide.Right)
+            val popup = popupProvider()
+            if (editor != null && popup != null) {
+                attachPopupToEditor(popup, editor, item)
+            }
+        }
+    }
+
+    private fun attachPopupToEditor(popup: WalkthroughPopupSurface, editor: Editor, item: WalkthroughItem) {
         val popupItem = if (isResolvableWalkthroughLine(item.line, editor.document.lineCount)) {
             moveCaretToLine(editor, item.line)
             item
@@ -187,7 +195,6 @@ private class DiffWalkthroughController(
             item.copy(line = null)
         }
         currentEditorUpdater(editor)
-        val popup = popupProvider() ?: return
         popup.update(editor, popupItem)
         popup.connectorHidden = false
         applyPopupGeometryForItem(popup, editor, popupItem)
@@ -209,16 +216,18 @@ private class DiffWalkthroughController(
         )
     }
 
-    private fun resolveDescriptor(item: WalkthroughItem): DiffWalkthroughDescriptor? {
-        item.diffId?.let { id ->
-            return descriptors.firstOrNull { descriptor -> descriptor.id == id }
-        }
-        val diffFile = item.diffFile ?: return descriptors.singleOrNull()
-        val matching = descriptors.filter { descriptor ->
-            diffFile == descriptor.file || diffFile == descriptor.leftFile || diffFile == descriptor.rightFile
-        }
-        return matching.singleOrNull()
-    }
+    private fun resolveDescriptor(item: WalkthroughItem): DiffWalkthroughDescriptor? =
+        item.diffId
+            ?.let { id -> descriptors.firstOrNull { descriptor -> descriptor.id == id } }
+            ?: item.diffFile?.let(::resolveDescriptorByFile)
+            ?: descriptors.singleOrNull()
+
+    private fun resolveDescriptorByFile(diffFile: String): DiffWalkthroughDescriptor? =
+        descriptors
+            .filter { descriptor ->
+                diffFile == descriptor.file || diffFile == descriptor.leftFile || diffFile == descriptor.rightFile
+            }
+            .singleOrNull()
 
     private fun selectEditor(viewer: EditorDiffViewer, side: DiffSide): Editor? {
         val editors = viewer.editors

--- a/src/main/kotlin/com/forketyfork/walkthrough/DiffWalkthroughSession.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/DiffWalkthroughSession.kt
@@ -18,9 +18,6 @@ import com.intellij.diff.util.Side as PlatformDiffSide
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.editor.Editor
-import com.intellij.openapi.fileEditor.FileEditorManager
-import com.intellij.openapi.fileEditor.FileEditorManagerEvent
-import com.intellij.openapi.fileEditor.FileEditorManagerListener
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.CheckedDisposable
@@ -33,6 +30,8 @@ import com.intellij.openapi.vcs.VcsException
 import com.intellij.vcsUtil.VcsUtil
 import git4idea.GitContentRevision
 import git4idea.GitRevisionNumber
+import java.awt.event.HierarchyEvent
+import java.awt.event.HierarchyListener
 import javax.swing.SwingUtilities
 
 private val DIFF_WALKTHROUGH_CONTROLLER_KEY: Key<DiffWalkthroughController> =
@@ -111,15 +110,6 @@ fun showDiffWalkthroughSession(
         onInteractionEnd = { saveCurrentGeometry(popupRef) }
     )
 
-    project.messageBus.connect(sessionDisposable).subscribe(
-        FileEditorManagerListener.FILE_EDITOR_MANAGER,
-        object : FileEditorManagerListener {
-            override fun selectionChanged(event: FileEditorManagerEvent) {
-                val selectedEditor = FileEditorManager.getInstance(project).selectedTextEditor
-                popupRef?.connectorHidden = selectedEditor?.document !== currentEditor?.document
-            }
-        }
-    )
     ApplicationManager.getApplication().messageBus.connect(sessionDisposable).subscribe(
         WalkthroughSettingsListener.TOPIC,
         object : WalkthroughSettingsListener {
@@ -178,13 +168,36 @@ private class DiffWalkthroughController(
     }
 
     fun attachToViewer(viewer: FrameDiffTool.DiffViewer, item: WalkthroughItem) {
-        if (!sessionDisposable.isDisposed && viewer is EditorDiffViewer) {
-            val editor = selectEditor(viewer, item.diffSide ?: DiffSide.Right)
-            val popup = popupProvider()
-            if (editor != null && popup != null) {
-                attachPopupToEditor(popup, editor, item)
+        if (sessionDisposable.isDisposed || viewer !is EditorDiffViewer) return
+        val editor = selectEditor(viewer, item.diffSide ?: DiffSide.Right)
+        val popup = popupProvider()
+        if (editor != null && popup != null) {
+            attachWhenShowing(popup, editor, item)
+        }
+    }
+
+    private fun attachWhenShowing(popup: WalkthroughPopupSurface, editor: Editor, item: WalkthroughItem) {
+        val component = editor.contentComponent
+        if (component.isShowing) {
+            attachPopupToEditor(popup, editor, item)
+            return
+        }
+        val listener = object : HierarchyListener {
+            override fun hierarchyChanged(event: HierarchyEvent) {
+                val showingChanged = event.changeFlags and HierarchyEvent.SHOWING_CHANGED.toLong() != 0L
+                if (showingChanged && component.isShowing) {
+                    component.removeHierarchyListener(this)
+                    if (!sessionDisposable.isDisposed) {
+                        attachPopupToEditor(popup, editor, item)
+                    }
+                }
             }
         }
+        component.addHierarchyListener(listener)
+        Disposer.register(
+            sessionDisposable,
+            Disposable { component.removeHierarchyListener(listener) }
+        )
     }
 
     private fun attachPopupToEditor(popup: WalkthroughPopupSurface, editor: Editor, item: WalkthroughItem) {

--- a/src/main/kotlin/com/forketyfork/walkthrough/DiffWalkthroughSession.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/DiffWalkthroughSession.kt
@@ -1,0 +1,323 @@
+package com.forketyfork.walkthrough
+
+import androidx.compose.runtime.mutableStateOf
+import com.intellij.diff.DiffContext
+import com.intellij.diff.DiffExtension
+import com.intellij.diff.DiffDialogHints
+import com.intellij.diff.DiffManager
+import com.intellij.diff.EditorDiffViewer
+import com.intellij.diff.FrameDiffTool
+import com.intellij.diff.chains.DiffRequestProducer
+import com.intellij.diff.chains.DiffRequestProducerException
+import com.intellij.diff.chains.SimpleDiffRequestChain
+import com.intellij.diff.contents.DiffContent
+import com.intellij.diff.requests.DiffRequest
+import com.intellij.diff.requests.SimpleDiffRequest
+import com.intellij.diff.util.DiffUserDataKeys
+import com.intellij.diff.util.Side as PlatformDiffSide
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.fileEditor.FileEditorManagerEvent
+import com.intellij.openapi.fileEditor.FileEditorManagerListener
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.CheckedDisposable
+import com.intellij.openapi.util.Disposer
+import com.intellij.openapi.util.Key
+import com.intellij.openapi.util.Pair
+import com.intellij.openapi.util.UserDataHolder
+import com.intellij.openapi.vcs.FilePath
+import com.intellij.openapi.vcs.VcsException
+import com.intellij.vcsUtil.VcsUtil
+import git4idea.GitContentRevision
+import git4idea.GitRevisionNumber
+import javax.swing.SwingUtilities
+
+private val DIFF_WALKTHROUGH_CONTROLLER_KEY: Key<DiffWalkthroughController> =
+    Key.create("walkthrough.diff.controller")
+private val DIFF_WALKTHROUGH_ITEM_KEY: Key<WalkthroughItem> =
+    Key.create("walkthrough.diff.item")
+private const val SHORT_COMMIT_LENGTH = 12
+
+@Suppress("LongMethod")
+fun showDiffWalkthroughSession(
+    project: Project,
+    descriptors: List<DiffWalkthroughDescriptor>,
+    items: List<WalkthroughItem>,
+    acceptsQuestions: Boolean
+): WalkthroughSession? {
+    if (descriptors.isEmpty() || items.isEmpty()) return null
+
+    val paletteState = mutableStateOf(WalkthroughSettings.getInstance().selectedPalette)
+    val sessionDisposable = Disposer.newCheckedDisposable("DiffWalkthroughPopupSession")
+    Disposer.register(project, sessionDisposable)
+
+    val registry = WalkthroughSessionRegistry.getInstance(project)
+    registry.swapActive(sessionDisposable)?.let(Disposer::dispose)
+    val session = registry.create(
+        items = items,
+        acceptsQuestions = acceptsQuestions,
+        targetKind = WalkthroughTargetKind.Diff,
+        diffDescriptors = descriptors
+    )
+    Disposer.register(
+        sessionDisposable,
+        object : Disposable {
+            override fun dispose() {
+                registry.remove(session.id)
+                registry.clearActive(sessionDisposable)
+            }
+        }
+    )
+
+    var popupRef: WalkthroughPopupSurface? = null
+    var currentEditor: Editor? = null
+    lateinit var controller: DiffWalkthroughController
+
+    fun updatePopupPalette(palette: WalkthroughPalette) {
+        SwingUtilities.invokeLater {
+            if (sessionDisposable.isDisposed) {
+                return@invokeLater
+            }
+            paletteState.value = palette
+            popupRef?.updatePalette(palette)
+        }
+    }
+
+    controller = DiffWalkthroughController(
+        project = project,
+        descriptors = descriptors,
+        sessionDisposable = sessionDisposable,
+        popupProvider = { popupRef },
+        currentEditorUpdater = { editor -> currentEditor = editor }
+    )
+
+    val panel = createWalkthroughPanel(
+        project = project,
+        session = session,
+        paletteProvider = { paletteState.value },
+        onItemDisplayed = controller::scheduleItemNavigation,
+        onNavigateToSource = controller::scheduleItemNavigation,
+        onClose = { popupRef?.cancel() }
+    )
+    makeComponentHierarchyTransparent(panel)
+
+    installPopupInteractionHandler(
+        panel = panel,
+        popupProvider = { popupRef },
+        editorProvider = { currentEditor },
+        onInteractionEnd = { saveCurrentGeometry(popupRef) }
+    )
+
+    project.messageBus.connect(sessionDisposable).subscribe(
+        FileEditorManagerListener.FILE_EDITOR_MANAGER,
+        object : FileEditorManagerListener {
+            override fun selectionChanged(event: FileEditorManagerEvent) {
+                val selectedEditor = FileEditorManager.getInstance(project).selectedTextEditor
+                popupRef?.connectorHidden = selectedEditor?.document !== currentEditor?.document
+            }
+        }
+    )
+    ApplicationManager.getApplication().messageBus.connect(sessionDisposable).subscribe(
+        WalkthroughSettingsListener.TOPIC,
+        object : WalkthroughSettingsListener {
+            override fun paletteChanged(palette: WalkthroughPalette) {
+                updatePopupPalette(palette)
+            }
+        }
+    )
+
+    val popup = WalkthroughPopupSurface(
+        content = panel,
+        palette = paletteState.value,
+        onCloseRequested = {
+            popupRef = null
+            registry.remove(session.id)
+            Disposer.dispose(sessionDisposable)
+        }
+    )
+    popupRef = popup
+    Disposer.register(sessionDisposable, popup)
+    controller.scheduleItemNavigation(items.first())
+    return session
+}
+
+class WalkthroughDiffExtension : DiffExtension() {
+    override fun onViewerCreated(
+        viewer: FrameDiffTool.DiffViewer,
+        context: DiffContext,
+        request: DiffRequest
+    ) {
+        val controller = request.getUserData(DIFF_WALKTHROUGH_CONTROLLER_KEY) ?: return
+        val item = request.getUserData(DIFF_WALKTHROUGH_ITEM_KEY) ?: return
+        controller.attachToViewer(viewer, item)
+    }
+}
+
+@Suppress("LongParameterList")
+private class DiffWalkthroughController(
+    private val project: Project,
+    private val descriptors: List<DiffWalkthroughDescriptor>,
+    private val sessionDisposable: CheckedDisposable,
+    private val popupProvider: () -> WalkthroughPopupSurface?,
+    private val currentEditorUpdater: (Editor) -> Unit
+) {
+    private var pendingNavigationId = 0
+
+    fun scheduleItemNavigation(item: WalkthroughItem) {
+        pendingNavigationId += 1
+        val navigationId = pendingNavigationId
+        SwingUtilities.invokeLater {
+            if (sessionDisposable.isDisposed || navigationId != pendingNavigationId) {
+                return@invokeLater
+            }
+            showItem(item)
+        }
+    }
+
+    fun attachToViewer(viewer: FrameDiffTool.DiffViewer, item: WalkthroughItem) {
+        if (sessionDisposable.isDisposed || viewer !is EditorDiffViewer) return
+        val editor = selectEditor(viewer, item.diffSide ?: DiffSide.Right) ?: return
+        val popupItem = if (isResolvableWalkthroughLine(item.line, editor.document.lineCount)) {
+            moveCaretToLine(editor, item.line)
+            item
+        } else {
+            item.copy(line = null)
+        }
+        currentEditorUpdater(editor)
+        val popup = popupProvider() ?: return
+        popup.update(editor, popupItem)
+        popup.connectorHidden = false
+        applyPopupGeometryForItem(popup, editor, popupItem)
+    }
+
+    private fun showItem(item: WalkthroughItem) {
+        val descriptor = resolveDescriptor(item) ?: return
+        DiffManager.getInstance().showDiff(
+            project,
+            SimpleDiffRequestChain.fromProducer(
+                DiffWalkthroughRequestProducer(
+                    project = project,
+                    descriptor = descriptor,
+                    item = item,
+                    controller = this
+                )
+            ),
+            DiffDialogHints.DEFAULT
+        )
+    }
+
+    private fun resolveDescriptor(item: WalkthroughItem): DiffWalkthroughDescriptor? {
+        item.diffId?.let { id ->
+            return descriptors.firstOrNull { descriptor -> descriptor.id == id }
+        }
+        val diffFile = item.diffFile ?: return descriptors.singleOrNull()
+        val matching = descriptors.filter { descriptor ->
+            diffFile == descriptor.file || diffFile == descriptor.leftFile || diffFile == descriptor.rightFile
+        }
+        return matching.singleOrNull()
+    }
+
+    private fun selectEditor(viewer: EditorDiffViewer, side: DiffSide): Editor? {
+        val editors = viewer.editors
+        return when (side) {
+            DiffSide.Left -> editors.getOrNull(0)
+            DiffSide.Right -> editors.getOrNull(1) ?: editors.getOrNull(0)
+        }
+    }
+}
+
+private class DiffWalkthroughRequestProducer(
+    private val project: Project,
+    private val descriptor: DiffWalkthroughDescriptor,
+    private val item: WalkthroughItem,
+    private val controller: DiffWalkthroughController
+) : DiffRequestProducer {
+    override fun getName(): String = descriptor.displayFile
+
+    override fun process(context: UserDataHolder, indicator: ProgressIndicator): DiffRequest =
+        try {
+            val leftPath = descriptor.leftFilePath()
+            val rightPath = descriptor.rightFilePath()
+            val leftContent = loadRevisionContent(
+                filePath = leftPath,
+                commit = descriptor.leftCommit
+            )
+            val rightContent = loadRevisionContent(
+                filePath = rightPath,
+                commit = descriptor.rightCommit
+            )
+            if (!leftContent.loaded && !rightContent.loaded) {
+                throw VcsException("Failed to load both revisions for ${descriptor.displayFile}")
+            }
+            SimpleDiffRequest(
+                descriptor.displayTitle,
+                leftContent.content,
+                rightContent.content,
+                descriptor.leftTitle,
+                descriptor.rightTitle
+            ).apply {
+                putUserData(DIFF_WALKTHROUGH_CONTROLLER_KEY, controller)
+                putUserData(DIFF_WALKTHROUGH_ITEM_KEY, item)
+                item.line?.let { line ->
+                    putUserData(
+                        DiffUserDataKeys.SCROLL_TO_LINE,
+                        Pair.create(item.diffSide.toPlatformSide(), (line - 1).coerceAtLeast(0))
+                    )
+                }
+                putUserData(DiffUserDataKeys.MASTER_SIDE, item.diffSide.toPlatformSide())
+            }
+        } catch (exception: VcsException) {
+            throw DiffRequestProducerException(exception)
+        } catch (exception: IllegalArgumentException) {
+            throw DiffRequestProducerException(exception)
+        }
+
+    private data class RevisionContent(val content: DiffContent, val loaded: Boolean)
+
+    private fun loadRevisionContent(filePath: FilePath, commit: String): RevisionContent {
+        val contentFactory = com.intellij.diff.DiffContentFactory.getInstance()
+        return try {
+            val revision = GitContentRevision.createRevision(filePath, GitRevisionNumber(commit), project)
+            val text = revision.content ?: return RevisionContent(contentFactory.createEmpty(), loaded = false)
+            RevisionContent(contentFactory.create(project, text, filePath), loaded = true)
+        } catch (_: VcsException) {
+            RevisionContent(contentFactory.createEmpty(), loaded = false)
+        }
+    }
+
+    private fun DiffWalkthroughDescriptor.leftFilePath(): FilePath =
+        resolveDiffFilePath(leftFile ?: file ?: rightFile)
+
+    private fun DiffWalkthroughDescriptor.rightFilePath(): FilePath =
+        resolveDiffFilePath(rightFile ?: file ?: leftFile)
+
+    private fun resolveDiffFilePath(relativePath: String?): FilePath {
+        require(!relativePath.isNullOrBlank()) { "Diff file path must not be blank" }
+        val absolutePath = resolveProjectRelativeWalkthroughPath(project.basePath, relativePath)
+            ?: throw IllegalArgumentException("Invalid project-relative diff path: $relativePath")
+        return VcsUtil.getFilePath(absolutePath.toString(), false)
+    }
+}
+
+private val DiffWalkthroughDescriptor.displayFile: String
+    get() = rightFile ?: file ?: leftFile ?: id
+
+private val DiffWalkthroughDescriptor.displayTitle: String
+    get() = "$displayFile: ${leftCommit.shortCommit()} vs ${rightCommit.shortCommit()}"
+
+private val DiffWalkthroughDescriptor.leftTitle: String
+    get() = leftCommit.shortCommit()
+
+private val DiffWalkthroughDescriptor.rightTitle: String
+    get() = rightCommit.shortCommit()
+
+private fun String.shortCommit(): String = take(SHORT_COMMIT_LENGTH)
+
+private fun DiffSide?.toPlatformSide(): PlatformDiffSide =
+    when (this) {
+        DiffSide.Left -> PlatformDiffSide.LEFT
+        DiffSide.Right, null -> PlatformDiffSide.RIGHT
+    }

--- a/src/main/kotlin/com/forketyfork/walkthrough/ResolvedWalkthroughTarget.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/ResolvedWalkthroughTarget.kt
@@ -80,7 +80,7 @@ private fun openEditor(
     }.getOrNull()
 }
 
-private fun moveCaretToLine(editor: Editor, line: Int?) {
+internal fun moveCaretToLine(editor: Editor, line: Int?) {
     if (line == null) return
     val lineIndex = line - 1
     editor.caretModel.moveToLogicalPosition(LogicalPosition(lineIndex, 0))

--- a/src/main/kotlin/com/forketyfork/walkthrough/ShowWalkthroughItemsToolset.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/ShowWalkthroughItemsToolset.kt
@@ -250,8 +250,8 @@ class ShowWalkthroughItemsToolset : McpToolset {
         val parsed = Gson().fromJson(payload, DiffWalkthroughPayloadJson::class.java)
             ?: mcpFail("payload must be a JSON object")
         val descriptors = parseDiffDescriptors(parsed.diffs.orEmpty())
-        val items = parseDiffItems(parsed.items.orEmpty(), descriptors)
         if (descriptors.isEmpty()) mcpFail("diffs must not be empty")
+        val items = parseDiffItems(parsed.items.orEmpty(), descriptors)
         if (items.isEmpty()) mcpFail("items must not be empty")
         ParsedDiffPayload(descriptors = descriptors, items = items)
     } catch (exception: JsonParseException) {

--- a/src/main/kotlin/com/forketyfork/walkthrough/ShowWalkthroughItemsToolset.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/ShowWalkthroughItemsToolset.kt
@@ -14,14 +14,38 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.withContext
 
-private data class WalkthroughItemJson(val text: String?, val file: String?, val line: Int?)
+private data class WalkthroughItemJson(
+    val text: String?,
+    val file: String?,
+    val line: Int?,
+    val diffId: String?,
+    val diffFile: String?,
+    val diffSide: String?
+)
+
+private data class DiffWalkthroughPayloadJson(
+    val diffs: List<DiffWalkthroughDescriptorJson>?,
+    val items: List<WalkthroughItemJson>?
+)
+
+private data class DiffWalkthroughDescriptorJson(
+    val id: String?,
+    val file: String?,
+    val leftFile: String?,
+    val rightFile: String?,
+    val leftCommit: String?,
+    val rightCommit: String?
+)
 
 class ShowWalkthroughItemsToolset : McpToolset {
     // Discovered and invoked via reflection by the MCP server framework
     @Suppress("unused")
     @McpTool(name = "show_walkthrough_items")
     @McpDescription(
-        "Shows and stores walkthrough items with navigation support. " +
+        "Shows and stores a file walkthrough anchored to normal project files. " +
+            "Use this when the user asks how code works, wants an architecture tour, asks for onboarding, " +
+            "or needs an explanation of existing behavior. Do not use this for PR review, branch review, " +
+            "commit review, or 'what changed' requests; use show_diff_walkthrough_items instead. " +
             "Accepts one or more walkthrough items; the user can cycle through them " +
             "with Previous and Next buttons. The walkthrough is saved to this project's history. " +
             "Top-level items are auto-labeled '1', '2', '3', etc. " +
@@ -40,7 +64,7 @@ class ShowWalkthroughItemsToolset : McpToolset {
             "JSON array of walkthrough items to display, e.g. " +
             "[{\"text\":\"Note 1\",\"file\":\"src/Foo.kt\",\"line\":10},{\"text\":\"Note 2\"}]. " +
             "Each item requires 'text'; 'file' (path relative to project root) and 'line' (1-based) are optional. " +
-            "The 'line' value navigates the editor to that exact position, so it must be accurate. " +
+            "The 'line' value is a line in the current full file, not a diff hunk line, so it must be accurate. " +
             "Verify line numbers by reading the actual file before calling this tool — do not estimate from diffs or memory."
         ) items: String
     ): String {
@@ -48,7 +72,7 @@ class ShowWalkthroughItemsToolset : McpToolset {
         val trimmedDescription = description.trim()
         if (trimmedDescription.isBlank()) mcpFail("description must not be blank")
 
-        val parsedItems = parseItems(items)
+        val parsedItems = parseFileItems(items)
         if (parsedItems.isEmpty()) mcpFail("items must not be empty")
 
         val labeledItems = assignTopLevelLabels(parsedItems)
@@ -70,13 +94,72 @@ class ShowWalkthroughItemsToolset : McpToolset {
     }
 
     @Suppress("unused")
+    @McpTool(name = "show_diff_walkthrough_items")
+    @McpDescription(
+        "Shows and stores a diff walkthrough anchored to IntelliJ IDEA diff viewers. " +
+            "Use this when the user asks about changes, a PR, a review, a commit, a branch comparison, " +
+            "a patch, or 'what changed'. Do not use this for general code explanation unless the user " +
+            "specifically wants the explanation in terms of a change. All items in one call must target " +
+            "Git commit-backed file diffs; do not mix file walkthrough items and diff walkthrough items. " +
+            "Do not submit file contents. Submit commit hashes for the two file revisions to compare. " +
+            "After this tool returns, immediately call await_walkthrough_question with the returned walkthroughId."
+    )
+    suspend fun showDiffWalkthroughItems(
+        @McpDescription(
+            "Short human-readable description shown in the project walkthrough history. " +
+            "Use a concise phrase that helps the user recognize this walkthrough later."
+        ) description: String,
+        @McpDescription(
+            "JSON object with 'diffs' and 'items'. 'diffs' supplies Git revisions to compare: " +
+            "'id', 'file', 'leftCommit', and 'rightCommit'; for renames, use 'leftFile' and 'rightFile' " +
+            "instead of 'file'. 'items' is an array with 'text', 'diffId', 'diffFile', 'diffSide', and 'line'. " +
+            "'diffSide' is 'left' or 'right'. 'line' is 1-based in that side's full file text at that commit, " +
+            "not the patch hunk line. Use 'right' for added or modified new code and 'left' for removed old code. " +
+            "For PRs, pass the merge-base commit as 'leftCommit' and the PR head commit as 'rightCommit'. " +
+            "Verify every line by inspecting that exact file at that exact commit before calling."
+        ) payload: String
+    ): String {
+        val project = requireProject()
+        val trimmedDescription = description.trim()
+        if (trimmedDescription.isBlank()) mcpFail("description must not be blank")
+
+        val parsedPayload = parseDiffPayload(payload)
+        val labeledItems = assignTopLevelLabels(parsedPayload.items)
+
+        val session = withContext(Dispatchers.EDT) {
+            showDiffWalkthroughSession(
+                project = project,
+                descriptors = parsedPayload.descriptors,
+                items = labeledItems,
+                acceptsQuestions = true
+            )
+        } ?: mcpFail("No diff walkthrough items to show")
+
+        val record = WalkthroughHistoryService.getInstance(project).save(
+            description = trimmedDescription,
+            targetKind = WalkthroughTargetKind.Diff,
+            diffDescriptors = parsedPayload.descriptors,
+            items = session.snapshotItems()
+        )
+
+        val labels = labeledItems.mapNotNull { it.label }.joinToString(", ")
+        val historySuffix = record
+            ?.let { "; saved to history as ${it.id}" }
+            ?: "; history was not saved"
+        return "Diff walkthrough shown with walkthroughId=${session.id} (steps: $labels)$historySuffix. " +
+            "Next: immediately call await_walkthrough_question with walkthroughId=${session.id} " +
+            "and keep waiting for questions until it returns dismissed."
+    }
+
+    @Suppress("unused")
     @McpTool(name = "await_walkthrough_question")
     @McpDescription(
         "Suspends until the user types a follow-up question into the active walkthrough popup " +
             "and presses Send, then returns the question text along with the label of the step " +
             "the user was viewing. Returns 'dismissed' if the user closes the popup before asking. " +
-            "Call this immediately after show_walkthrough_items returns, and call it again after each " +
-            "insert_walkthrough_tangents response. Keep waiting in this loop until this tool returns dismissed. " +
+            "Call this immediately after show_walkthrough_items or show_diff_walkthrough_items returns, " +
+            "and call it again after each insert_walkthrough_tangents response. " +
+            "Keep waiting in this loop until this tool returns dismissed. " +
             "Call insert_walkthrough_tangents to splice each answer into the walkthrough as labeled child steps."
     )
     suspend fun awaitWalkthroughQuestion(
@@ -115,9 +198,10 @@ class ShowWalkthroughItemsToolset : McpToolset {
             "Must match the parentLabel reported by await_walkthrough_question."
         ) parentLabel: String,
         @McpDescription(
-            "JSON array of walkthrough items to insert as children, same shape as show_walkthrough_items: " +
-            "[{\"text\":\"…\",\"file\":\"src/Foo.kt\",\"line\":10}, …]. " +
-            "Verify line numbers against the actual file before calling."
+            "JSON array of walkthrough items to insert as children. For file walkthroughs, use the same item " +
+            "shape as show_walkthrough_items. For diff walkthroughs, use diff item fields from " +
+            "show_diff_walkthrough_items: 'text', 'diffId', 'diffFile', 'diffSide', and 'line'. " +
+            "Verify line numbers against the actual file or exact diff side before calling."
         ) items: String
     ): String {
         val project = requireProject()
@@ -125,7 +209,10 @@ class ShowWalkthroughItemsToolset : McpToolset {
         if (trimmedParent.isBlank()) mcpFail("parentLabel must not be blank")
         val session = WalkthroughSessionRegistry.getInstance(project).get(walkthroughId)
             ?: mcpFail("Unknown walkthroughId: $walkthroughId")
-        val parsedItems = parseItems(items)
+        val parsedItems = when (session.targetKind) {
+            WalkthroughTargetKind.File -> parseFileItems(items)
+            WalkthroughTargetKind.Diff -> parseDiffItems(items, session.diffDescriptors)
+        }
         if (parsedItems.isEmpty()) mcpFail("items must not be empty")
 
         val inserted = withContext(Dispatchers.EDT) {
@@ -138,7 +225,7 @@ class ShowWalkthroughItemsToolset : McpToolset {
     private suspend fun requireProject(): Project =
         currentCoroutineContext().projectOrNull ?: mcpFail("No active project")
 
-    private fun parseItems(items: String): List<WalkthroughItem> = try {
+    private fun parseFileItems(items: String): List<WalkthroughItem> = try {
         val type = object : TypeToken<List<WalkthroughItemJson>>() {}.type
         val parsed: List<WalkthroughItemJson> = Gson().fromJson(items, type)
         parsed.map { entry ->
@@ -153,4 +240,86 @@ class ShowWalkthroughItemsToolset : McpToolset {
     } catch (exception: IllegalStateException) {
         mcpFail("Invalid items JSON: ${exception.message}")
     }
+
+    private data class ParsedDiffPayload(
+        val descriptors: List<DiffWalkthroughDescriptor>,
+        val items: List<WalkthroughItem>
+    )
+
+    private fun parseDiffPayload(payload: String): ParsedDiffPayload = try {
+        val parsed = Gson().fromJson(payload, DiffWalkthroughPayloadJson::class.java)
+            ?: mcpFail("payload must be a JSON object")
+        val descriptors = parseDiffDescriptors(parsed.diffs.orEmpty())
+        val items = parseDiffItems(parsed.items.orEmpty(), descriptors)
+        if (descriptors.isEmpty()) mcpFail("diffs must not be empty")
+        if (items.isEmpty()) mcpFail("items must not be empty")
+        ParsedDiffPayload(descriptors = descriptors, items = items)
+    } catch (exception: JsonParseException) {
+        mcpFail("Invalid payload JSON: ${exception.message}")
+    } catch (exception: IllegalStateException) {
+        mcpFail("Invalid payload JSON: ${exception.message}")
+    }
+
+    private fun parseDiffDescriptors(entries: List<DiffWalkthroughDescriptorJson>): List<DiffWalkthroughDescriptor> {
+        val descriptors = entries.map { entry ->
+            val file = entry.file?.trim()?.takeIf { it.isNotBlank() }
+            val leftFile = entry.leftFile?.trim()?.takeIf { it.isNotBlank() }
+            val rightFile = entry.rightFile?.trim()?.takeIf { it.isNotBlank() }
+            if (file == null && (leftFile == null || rightFile == null)) {
+                mcpFail("Each diff requires either 'file' or both 'leftFile' and 'rightFile'")
+            }
+            DiffWalkthroughDescriptor(
+                id = entry.id?.trim()?.takeIf { it.isNotBlank() }
+                    ?: mcpFail("Each diff must have an 'id' field"),
+                file = file,
+                leftFile = leftFile,
+                rightFile = rightFile,
+                leftCommit = entry.leftCommit?.trim()?.takeIf { it.isNotBlank() }
+                    ?: mcpFail("Each diff must have a 'leftCommit' field"),
+                rightCommit = entry.rightCommit?.trim()?.takeIf { it.isNotBlank() }
+                    ?: mcpFail("Each diff must have a 'rightCommit' field")
+            )
+        }
+        val duplicateId = descriptors.groupBy { it.id }.entries.firstOrNull { it.value.size > 1 }?.key
+        if (duplicateId != null) mcpFail("Duplicate diff id: $duplicateId")
+        return descriptors
+    }
+
+    private fun parseDiffItems(items: String, descriptors: List<DiffWalkthroughDescriptor>): List<WalkthroughItem> = try {
+        val type = object : TypeToken<List<WalkthroughItemJson>>() {}.type
+        val parsed: List<WalkthroughItemJson> = Gson().fromJson(items, type)
+        parseDiffItems(parsed, descriptors)
+    } catch (exception: JsonParseException) {
+        mcpFail("Invalid items JSON: ${exception.message}")
+    } catch (exception: IllegalStateException) {
+        mcpFail("Invalid items JSON: ${exception.message}")
+    }
+
+    private fun parseDiffItems(
+        entries: List<WalkthroughItemJson>,
+        descriptors: List<DiffWalkthroughDescriptor>
+    ): List<WalkthroughItem> =
+        entries.map { entry ->
+            val diffId = entry.diffId?.trim()?.takeIf { it.isNotBlank() }
+                ?: mcpFail("Each diff item must have a 'diffId' field")
+            val descriptor = descriptors.firstOrNull { it.id == diffId }
+                ?: mcpFail("Unknown diffId: $diffId")
+            WalkthroughItem(
+                text = entry.text ?: mcpFail("Each item must have a 'text' field"),
+                line = entry.line ?: mcpFail("Each diff item must have a 'line' field"),
+                diffId = diffId,
+                diffFile = entry.diffFile?.trim()?.takeIf { it.isNotBlank() }
+                    ?: descriptor.file
+                    ?: descriptor.rightFile
+                    ?: descriptor.leftFile,
+                diffSide = parseDiffSide(entry.diffSide)
+            )
+        }
+
+    private fun parseDiffSide(value: String?): DiffSide =
+        when (value?.trim()?.lowercase()) {
+            "left" -> DiffSide.Left
+            "right" -> DiffSide.Right
+            else -> mcpFail("Each diff item must have 'diffSide' set to 'left' or 'right'")
+        }
 }

--- a/src/main/kotlin/com/forketyfork/walkthrough/ShowWalkthroughItemsToolset.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/ShowWalkthroughItemsToolset.kt
@@ -24,11 +24,11 @@ private data class WalkthroughItemJson(
 )
 
 private data class DiffWalkthroughPayloadJson(
-    val diffs: List<DiffWalkthroughDescriptorJson>?,
+    val diffs: List<ToolDiffWalkthroughDescriptorJson>?,
     val items: List<WalkthroughItemJson>?
 )
 
-private data class DiffWalkthroughDescriptorJson(
+private data class ToolDiffWalkthroughDescriptorJson(
     val id: String?,
     val file: String?,
     val leftFile: String?,
@@ -260,7 +260,9 @@ class ShowWalkthroughItemsToolset : McpToolset {
         mcpFail("Invalid payload JSON: ${exception.message}")
     }
 
-    private fun parseDiffDescriptors(entries: List<DiffWalkthroughDescriptorJson>): List<DiffWalkthroughDescriptor> {
+    private fun parseDiffDescriptors(
+        entries: List<ToolDiffWalkthroughDescriptorJson>
+    ): List<DiffWalkthroughDescriptor> {
         val descriptors = entries.map { entry ->
             val file = entry.file?.trim()?.takeIf { it.isNotBlank() }
             val leftFile = entry.leftFile?.trim()?.takeIf { it.isNotBlank() }
@@ -285,7 +287,10 @@ class ShowWalkthroughItemsToolset : McpToolset {
         return descriptors
     }
 
-    private fun parseDiffItems(items: String, descriptors: List<DiffWalkthroughDescriptor>): List<WalkthroughItem> = try {
+    private fun parseDiffItems(
+        items: String,
+        descriptors: List<DiffWalkthroughDescriptor>
+    ): List<WalkthroughItem> = try {
         val type = object : TypeToken<List<WalkthroughItemJson>>() {}.type
         val parsed: List<WalkthroughItemJson> = Gson().fromJson(items, type)
         parseDiffItems(parsed, descriptors)

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughAnchorFallback.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughAnchorFallback.kt
@@ -6,7 +6,7 @@ internal fun isResolvableWalkthroughLine(line: Int?, lineCount: Int): Boolean =
     line == null || line in 1..lineCount.coerceAtLeast(1)
 
 internal fun WalkthroughItem.withFallbackAnchor(): WalkthroughItem =
-    copy(file = null, line = null)
+    copy(file = null, line = null, diffId = null, diffFile = null, diffSide = null)
 
 internal fun resolveProjectRelativeWalkthroughPath(basePath: String?, relativePath: String): Path? =
     runCatching {

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughHistoryAction.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughHistoryAction.kt
@@ -46,7 +46,15 @@ private class ReplayWalkthroughAction(
     private val record: WalkthroughRecord
 ) : AnAction(formatRecord(record)) {
     override fun actionPerformed(event: AnActionEvent) {
-        val shown = showWalkthroughItems(project, record.items)
+        val shown = when (record.targetKind) {
+            WalkthroughTargetKind.File -> showWalkthroughItems(project, record.items)
+            WalkthroughTargetKind.Diff -> showDiffWalkthroughSession(
+                project = project,
+                descriptors = record.diffDescriptors,
+                items = record.items,
+                acceptsQuestions = false
+            ) != null
+        }
         if (!shown) {
             JBPopupFactory.getInstance()
                 .createMessage("No active editor for walkthrough replay")

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughHistoryService.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughHistoryService.kt
@@ -21,6 +21,16 @@ class WalkthroughHistoryService(private val project: Project) {
             store?.save(description, items)
         }
 
+    fun save(
+        description: String,
+        targetKind: WalkthroughTargetKind,
+        diffDescriptors: List<DiffWalkthroughDescriptor>,
+        items: List<WalkthroughItem>
+    ): WalkthroughRecord? =
+        runHistoryOperation(operation = "save walkthrough history", fallback = null) {
+            store?.save(description, targetKind, diffDescriptors, items)
+        }
+
     fun list(): List<WalkthroughRecord> =
         runHistoryOperation(operation = "list walkthrough history", fallback = emptyList()) {
             store?.list().orEmpty()

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughHistoryStore.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughHistoryStore.kt
@@ -185,21 +185,33 @@ internal class WalkthroughHistoryStore(
 
     private fun validateRecord(record: WalkthroughRecord) {
         val hasValidCreatedAt = runCatching { Instant.parse(record.createdAt) }.isSuccess
+        val hasValidTargetKind = when (record.targetKind) {
+            WalkthroughTargetKind.File -> record.diffDescriptors.isEmpty()
+            WalkthroughTargetKind.Diff -> record.diffDescriptors.isNotEmpty()
+        }
+        val hasValidDescriptors = record.diffDescriptors.all { descriptor ->
+            descriptor.id.isNotBlank() &&
+                descriptor.leftCommit.isNotBlank() &&
+                descriptor.rightCommit.isNotBlank() &&
+                descriptor.hasUsablePath()
+        }
         val hasValidFields = isSafeRecordId(record.id) &&
             record.description.isNotBlank() &&
             record.items.isNotEmpty() &&
             record.items.all { item -> item.text.isNotBlank() } &&
-            (record.targetKind == WalkthroughTargetKind.File || record.diffDescriptors.isNotEmpty()) &&
-            record.diffDescriptors.all { descriptor ->
-                descriptor.id.isNotBlank() &&
-                    descriptor.leftCommit.isNotBlank() &&
-                    descriptor.rightCommit.isNotBlank()
-            }
+            hasValidTargetKind &&
+            hasValidDescriptors
 
         if (!hasValidCreatedAt || !hasValidFields) {
             throw JsonParseException("Invalid walkthrough history record")
         }
     }
+}
+
+private fun DiffWalkthroughDescriptor.hasUsablePath(): Boolean {
+    val hasSharedFile = !file.isNullOrBlank()
+    val hasBothSideFiles = !leftFile.isNullOrBlank() && !rightFile.isNullOrBlank()
+    return hasSharedFile || hasBothSideFiles
 }
 
 internal fun slugifyDescription(description: String): String =

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughHistoryStore.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughHistoryStore.kt
@@ -32,13 +32,27 @@ private data class WalkthroughRecordJson(
     val id: String?,
     val createdAt: String?,
     val description: String?,
+    val targetKind: WalkthroughTargetKind?,
+    val diffDescriptors: List<DiffWalkthroughDescriptorJson>?,
     val items: List<WalkthroughRecordItemJson>?
+)
+
+private data class DiffWalkthroughDescriptorJson(
+    val id: String?,
+    val file: String?,
+    val leftFile: String?,
+    val rightFile: String?,
+    val leftCommit: String?,
+    val rightCommit: String?
 )
 
 private data class WalkthroughRecordItemJson(
     val text: String?,
     val file: String?,
     val line: Int?,
+    val diffId: String?,
+    val diffFile: String?,
+    val diffSide: DiffSide?,
     val label: String?,
     val parentLabel: String?
 )
@@ -55,6 +69,20 @@ internal class WalkthroughHistoryStore(
         .create()
 
     fun save(description: String, items: List<WalkthroughItem>): WalkthroughRecord {
+        return save(
+            description = description,
+            targetKind = WalkthroughTargetKind.File,
+            diffDescriptors = emptyList(),
+            items = items
+        )
+    }
+
+    fun save(
+        description: String,
+        targetKind: WalkthroughTargetKind,
+        diffDescriptors: List<DiffWalkthroughDescriptor>,
+        items: List<WalkthroughItem>
+    ): WalkthroughRecord {
         require(description.isNotBlank()) { "description must not be blank" }
         require(items.isNotEmpty()) { "items must not be empty" }
 
@@ -63,6 +91,8 @@ internal class WalkthroughHistoryStore(
             id = createRecordId(createdAt, description),
             createdAt = createdAt.toString(),
             description = description,
+            targetKind = targetKind,
+            diffDescriptors = diffDescriptors,
             items = items
         )
         save(record)
@@ -158,7 +188,13 @@ internal class WalkthroughHistoryStore(
         val hasValidFields = isSafeRecordId(record.id) &&
             record.description.isNotBlank() &&
             record.items.isNotEmpty() &&
-            record.items.all { item -> item.text.isNotBlank() }
+            record.items.all { item -> item.text.isNotBlank() } &&
+            (record.targetKind == WalkthroughTargetKind.File || record.diffDescriptors.isNotEmpty()) &&
+            record.diffDescriptors.all { descriptor ->
+                descriptor.id.isNotBlank() &&
+                    descriptor.leftCommit.isNotBlank() &&
+                    descriptor.rightCommit.isNotBlank()
+            }
 
         if (!hasValidCreatedAt || !hasValidFields) {
             throw JsonParseException("Invalid walkthrough history record")
@@ -180,16 +216,42 @@ private fun WalkthroughRecordJson.toRecord(): WalkthroughRecord? {
     val parsedId = id?.takeIf(::isSafeRecordId)
     val parsedCreatedAt = createdAt?.takeIf { value -> runCatching { Instant.parse(value) }.isSuccess }
     val parsedDescription = description?.takeIf { value -> value.isNotBlank() }
+    val parsedTargetKind = targetKind ?: WalkthroughTargetKind.File
+    val parsedDiffDescriptors = diffDescriptors?.mapNotNull { descriptor ->
+        descriptor.toDiffWalkthroughDescriptorOrNull()
+    } ?: emptyList()
     val parsedItems = items?.mapNotNull { item -> item.toWalkthroughItemOrNull() }
     val hasRequiredFields = parsedId != null && parsedCreatedAt != null && parsedDescription != null
     val hasMatchingItems = parsedItems != null && parsedItems.size == items.size && parsedItems.isNotEmpty()
+    val hasMatchingDiffDescriptors = diffDescriptors == null ||
+        parsedDiffDescriptors.size == diffDescriptors.size
 
-    return if (hasRequiredFields && hasMatchingItems) {
+    return if (hasRequiredFields && hasMatchingItems && hasMatchingDiffDescriptors) {
         WalkthroughRecord(
             id = parsedId.orEmpty(),
             createdAt = parsedCreatedAt.orEmpty(),
             description = parsedDescription.orEmpty(),
+            targetKind = parsedTargetKind,
+            diffDescriptors = parsedDiffDescriptors,
             items = parsedItems.orEmpty()
+        )
+    } else {
+        null
+    }
+}
+
+private fun DiffWalkthroughDescriptorJson.toDiffWalkthroughDescriptorOrNull(): DiffWalkthroughDescriptor? {
+    val parsedId = id?.takeIf { it.isNotBlank() }
+    val parsedLeftCommit = leftCommit?.takeIf { it.isNotBlank() }
+    val parsedRightCommit = rightCommit?.takeIf { it.isNotBlank() }
+    return if (parsedId != null && parsedLeftCommit != null && parsedRightCommit != null) {
+        DiffWalkthroughDescriptor(
+            id = parsedId,
+            file = file?.takeIf { it.isNotBlank() },
+            leftFile = leftFile?.takeIf { it.isNotBlank() },
+            rightFile = rightFile?.takeIf { it.isNotBlank() },
+            leftCommit = parsedLeftCommit,
+            rightCommit = parsedRightCommit
         )
     } else {
         null
@@ -204,6 +266,9 @@ private fun WalkthroughRecordItemJson.toWalkthroughItemOrNull(): WalkthroughItem
                 text = value,
                 file = file,
                 line = line,
+                diffId = diffId?.takeIf { it.isNotBlank() },
+                diffFile = diffFile?.takeIf { it.isNotBlank() },
+                diffSide = diffSide,
                 label = label?.takeIf { it.isNotBlank() },
                 parentLabel = parentLabel?.takeIf { it.isNotBlank() }
             )

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughItem.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughItem.kt
@@ -2,6 +2,25 @@ package com.forketyfork.walkthrough
 
 import java.awt.Dimension
 
+enum class WalkthroughTargetKind {
+    File,
+    Diff
+}
+
+enum class DiffSide {
+    Left,
+    Right
+}
+
+data class DiffWalkthroughDescriptor(
+    val id: String,
+    val file: String? = null,
+    val leftFile: String? = null,
+    val rightFile: String? = null,
+    val leftCommit: String,
+    val rightCommit: String
+)
+
 internal object WalkthroughPopupLayout {
     val fallbackSize = Dimension(560, 360)
     const val MINIMUM_WIDTH_PX = 520
@@ -14,6 +33,9 @@ data class WalkthroughItem(
     val text: String,
     val file: String? = null,
     val line: Int? = null,
+    val diffId: String? = null,
+    val diffFile: String? = null,
+    val diffSide: DiffSide? = null,
     val label: String? = null,
     val parentLabel: String? = null
 )

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughOrchestrator.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughOrchestrator.kt
@@ -153,7 +153,7 @@ fun showWalkthroughSession(
     return session
 }
 
-private fun saveCurrentGeometry(popup: WalkthroughPopupSurface?) {
+internal fun saveCurrentGeometry(popup: WalkthroughPopupSurface?) {
     val location = popup?.popupLocationOnScreen() ?: return
     val size = resolvePopupSize(popup) ?: return
     WalkthroughSettings.getInstance().saveGeometry(
@@ -161,7 +161,7 @@ private fun saveCurrentGeometry(popup: WalkthroughPopupSurface?) {
     )
 }
 
-private fun applyPopupGeometryForItem(
+internal fun applyPopupGeometryForItem(
     popup: WalkthroughPopupSurface,
     editor: Editor,
     item: WalkthroughItem
@@ -198,7 +198,7 @@ private fun applyPopupGeometryForItem(
     }
 }
 
-private fun createWalkthroughPanel(
+internal fun createWalkthroughPanel(
     project: Project,
     session: WalkthroughSession,
     paletteProvider: () -> WalkthroughPalette,

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupContent.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupContent.kt
@@ -236,7 +236,7 @@ private fun WalkthroughPopupFrame(
                 showScrollbar = showScrollbar
             )
             val showNavigation = items.size > 1
-            val sourceCallback = onNavigateToSource.takeIf { item.file != null || item.line != null }
+            val sourceCallback = onNavigateToSource.takeIf { item.hasNavigationTarget() }
             if (showNavigation || sourceCallback != null) {
                 WalkthroughPopupNavigation(
                     showNavigation = showNavigation,
@@ -258,6 +258,9 @@ private fun WalkthroughPopupFrame(
         }
     }
 }
+
+private fun WalkthroughItem.hasNavigationTarget(): Boolean =
+    file != null || line != null || diffId != null || diffFile != null
 
 private fun Modifier.walkthroughPopupBackground(
     animationState: WalkthroughPopupAnimationState,

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupInteraction.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupInteraction.kt
@@ -65,27 +65,15 @@ internal fun installPopupInteractionHandler(
         }
 
         override fun mouseDragged(event: MouseEvent) {
-            val mode = interactionMode ?: return
-            val popup = popupProvider() ?: return
-            val previousScreenPoint = lastScreenPoint ?: event.locationOnScreen
-            val currentScreenPoint = event.locationOnScreen
-            when (mode) {
-                PopupInteractionMode.Drag -> movePopupBy(
-                    popup = popup,
-                    editor = editorProvider() ?: return,
-                    deltaX = (currentScreenPoint.x - previousScreenPoint.x).toFloat(),
-                    deltaY = (currentScreenPoint.y - previousScreenPoint.y).toFloat()
-                )
-
-                PopupInteractionMode.Resize -> resizePopupBy(
-                    popup = popup,
-                    panel = panel,
-                    editor = editorProvider() ?: return,
-                    deltaX = (currentScreenPoint.x - previousScreenPoint.x).toFloat(),
-                    deltaY = (currentScreenPoint.y - previousScreenPoint.y).toFloat()
-                )
+            val mode = interactionMode
+            val popup = popupProvider()
+            val editor = editorProvider()
+            if (mode != null && popup != null && editor != null) {
+                val previousScreenPoint = lastScreenPoint ?: event.locationOnScreen
+                val currentScreenPoint = event.locationOnScreen
+                handlePopupDrag(panel, mode, popup, editor, previousScreenPoint, currentScreenPoint)
+                lastScreenPoint = currentScreenPoint
             }
-            lastScreenPoint = currentScreenPoint
         }
 
         override fun mouseMoved(event: MouseEvent) {
@@ -157,6 +145,32 @@ private fun updateInteractionCursor(panel: JComponent, component: Component, poi
     }
     component.cursor = cursor
     panel.cursor = cursor
+}
+
+private fun handlePopupDrag(
+    panel: JComponent,
+    mode: PopupInteractionMode,
+    popup: WalkthroughPopupSurface,
+    editor: Editor,
+    previousScreenPoint: Point,
+    currentScreenPoint: Point
+) {
+    when (mode) {
+        PopupInteractionMode.Drag -> movePopupBy(
+            popup = popup,
+            editor = editor,
+            deltaX = (currentScreenPoint.x - previousScreenPoint.x).toFloat(),
+            deltaY = (currentScreenPoint.y - previousScreenPoint.y).toFloat()
+        )
+
+        PopupInteractionMode.Resize -> resizePopupBy(
+            popup = popup,
+            panel = panel,
+            editor = editor,
+            deltaX = (currentScreenPoint.x - previousScreenPoint.x).toFloat(),
+            deltaY = (currentScreenPoint.y - previousScreenPoint.y).toFloat()
+        )
+    }
 }
 
 private fun isWithinDragHandle(panel: JComponent, component: Component, point: Point): Boolean {

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupInteraction.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupInteraction.kt
@@ -43,7 +43,7 @@ internal fun makeComponentHierarchyTransparent(component: Component?) {
 internal fun installPopupInteractionHandler(
     panel: JComponent,
     popupProvider: () -> WalkthroughPopupSurface?,
-    editorProvider: () -> Editor,
+    editorProvider: () -> Editor?,
     onInteractionEnd: () -> Unit
 ) {
     var lastScreenPoint: Point? = null
@@ -72,7 +72,7 @@ internal fun installPopupInteractionHandler(
             when (mode) {
                 PopupInteractionMode.Drag -> movePopupBy(
                     popup = popup,
-                    editor = editorProvider(),
+                    editor = editorProvider() ?: return,
                     deltaX = (currentScreenPoint.x - previousScreenPoint.x).toFloat(),
                     deltaY = (currentScreenPoint.y - previousScreenPoint.y).toFloat()
                 )
@@ -80,7 +80,7 @@ internal fun installPopupInteractionHandler(
                 PopupInteractionMode.Resize -> resizePopupBy(
                     popup = popup,
                     panel = panel,
-                    editor = editorProvider(),
+                    editor = editorProvider() ?: return,
                     deltaX = (currentScreenPoint.x - previousScreenPoint.x).toFloat(),
                     deltaY = (currentScreenPoint.y - previousScreenPoint.y).toFloat()
                 )

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughRecord.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughRecord.kt
@@ -6,6 +6,8 @@ data class WalkthroughRecord(
     val id: String,
     val createdAt: String,
     val description: String,
+    val targetKind: WalkthroughTargetKind = WalkthroughTargetKind.File,
+    val diffDescriptors: List<DiffWalkthroughDescriptor> = emptyList(),
     val items: List<WalkthroughItem>
 )
 

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughSessionRegistry.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughSessionRegistry.kt
@@ -21,6 +21,8 @@ data class WalkthroughTangentQuestion(
 class WalkthroughSession internal constructor(
     val id: String,
     initialItems: List<WalkthroughItem>,
+    val targetKind: WalkthroughTargetKind,
+    val diffDescriptors: List<DiffWalkthroughDescriptor>,
     internal val acceptsQuestions: Boolean
 ) {
     internal val items: SnapshotStateList<WalkthroughItem> =
@@ -99,10 +101,17 @@ class WalkthroughSessionRegistry {
         activeSessionDisposable.compareAndSet(disposable, null)
     }
 
-    internal fun create(items: List<WalkthroughItem>, acceptsQuestions: Boolean): WalkthroughSession {
+    internal fun create(
+        items: List<WalkthroughItem>,
+        acceptsQuestions: Boolean,
+        targetKind: WalkthroughTargetKind = WalkthroughTargetKind.File,
+        diffDescriptors: List<DiffWalkthroughDescriptor> = emptyList()
+    ): WalkthroughSession {
         val session = WalkthroughSession(
             id = UUID.randomUUID().toString(),
             initialItems = items,
+            targetKind = targetKind,
+            diffDescriptors = diffDescriptors,
             acceptsQuestions = acceptsQuestions
         )
         sessions[session.id] = session

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -22,6 +22,7 @@
     <dependencies>
         <plugin id="com.intellij.modules.compose"/>
         <plugin id="com.intellij.mcpServer"/>
+        <plugin id="Git4Idea"/>
         <module name="intellij.platform.compose.markdown"/>
     </dependencies>
 
@@ -36,6 +37,7 @@
                 instance="com.forketyfork.walkthrough.WalkthroughSettingsConfigurable"
                 id="com.forketyfork.walkthrough.settings"
                 displayName="Walkthrough"/>
+        <diff.DiffExtension implementation="com.forketyfork.walkthrough.WalkthroughDiffExtension"/>
     </extensions>
 
     <extensions defaultExtensionNs="com.intellij.mcpServer">

--- a/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughHistoryStoreTest.kt
+++ b/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughHistoryStoreTest.kt
@@ -1,6 +1,7 @@
 package com.forketyfork.walkthrough
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -117,5 +118,114 @@ class WalkthroughHistoryStoreTest {
     fun slugifyKeepsFileNamesInspectable() {
         assertEquals("explain-popup-placement", slugifyDescription("Explain popup placement"))
         assertEquals("", slugifyDescription("!!!"))
+    }
+
+    @Test
+    fun saveRejectsFileRecordCarryingDiffDescriptors() {
+        val store = WalkthroughHistoryStore(directory = tempDir)
+        val record = WalkthroughRecord(
+            id = "20260509-043400-000-mismatched-abc12345",
+            createdAt = "2026-05-09T04:34:00Z",
+            description = "Mismatched",
+            targetKind = WalkthroughTargetKind.File,
+            diffDescriptors = listOf(
+                DiffWalkthroughDescriptor(
+                    id = "stray",
+                    file = "src/Foo.kt",
+                    leftCommit = "1111111111111111111111111111111111111111",
+                    rightCommit = "2222222222222222222222222222222222222222"
+                )
+            ),
+            items = listOf(WalkthroughItem(text = "Step"))
+        )
+
+        assertThrows(com.google.gson.JsonParseException::class.java) { store.save(record) }
+    }
+
+    @Test
+    fun saveRejectsDiffRecordWithoutDescriptors() {
+        val store = WalkthroughHistoryStore(directory = tempDir)
+        val record = WalkthroughRecord(
+            id = "20260509-043400-000-empty-diff-abc12345",
+            createdAt = "2026-05-09T04:34:00Z",
+            description = "Empty diff",
+            targetKind = WalkthroughTargetKind.Diff,
+            diffDescriptors = emptyList(),
+            items = listOf(
+                WalkthroughItem(
+                    text = "Step",
+                    line = 1,
+                    diffId = "missing",
+                    diffSide = DiffSide.Right
+                )
+            )
+        )
+
+        assertThrows(com.google.gson.JsonParseException::class.java) { store.save(record) }
+    }
+
+    @Test
+    fun saveRejectsDiffDescriptorWithoutUsablePath() {
+        val store = WalkthroughHistoryStore(directory = tempDir)
+        val record = WalkthroughRecord(
+            id = "20260509-043400-000-no-path-abc12345",
+            createdAt = "2026-05-09T04:34:00Z",
+            description = "No path",
+            targetKind = WalkthroughTargetKind.Diff,
+            diffDescriptors = listOf(
+                DiffWalkthroughDescriptor(
+                    id = "no-path",
+                    leftCommit = "1111111111111111111111111111111111111111",
+                    rightCommit = "2222222222222222222222222222222222222222"
+                )
+            ),
+            items = listOf(
+                WalkthroughItem(
+                    text = "Step",
+                    line = 1,
+                    diffId = "no-path",
+                    diffSide = DiffSide.Right
+                )
+            )
+        )
+
+        assertThrows(com.google.gson.JsonParseException::class.java) { store.save(record) }
+    }
+
+    @Test
+    fun saveAcceptsDiffDescriptorWithOnlySideFiles() {
+        val store = WalkthroughHistoryStore(
+            directory = tempDir,
+            clock = Clock.fixed(Instant.parse("2026-05-09T04:34:00Z"), ZoneOffset.UTC),
+            randomSuffix = { "abc12345" }
+        )
+        val descriptors = listOf(
+            DiffWalkthroughDescriptor(
+                id = "renamed",
+                leftFile = "src/Old.kt",
+                rightFile = "src/New.kt",
+                leftCommit = "1111111111111111111111111111111111111111",
+                rightCommit = "2222222222222222222222222222222222222222"
+            )
+        )
+        val items = listOf(
+            WalkthroughItem(
+                text = "Renamed file step",
+                line = 1,
+                diffId = "renamed",
+                diffFile = "src/New.kt",
+                diffSide = DiffSide.Right
+            )
+        )
+
+        val saved = store.save(
+            description = "Renamed",
+            targetKind = WalkthroughTargetKind.Diff,
+            diffDescriptors = descriptors,
+            items = items
+        )
+
+        assertEquals(descriptors, saved.diffDescriptors)
+        assertEquals(saved, store.load(saved.id))
     }
 }

--- a/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughHistoryStoreTest.kt
+++ b/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughHistoryStoreTest.kt
@@ -41,6 +41,44 @@ class WalkthroughHistoryStoreTest {
     }
 
     @Test
+    fun saveListAndLoadRoundTripDiffWalkthroughRecord() {
+        val store = WalkthroughHistoryStore(
+            directory = tempDir,
+            clock = Clock.fixed(Instant.parse("2026-05-09T04:34:00Z"), ZoneOffset.UTC),
+            randomSuffix = { "abc12345" }
+        )
+        val descriptors = listOf(
+            DiffWalkthroughDescriptor(
+                id = "popup-change",
+                file = "src/Foo.kt",
+                leftCommit = "1111111111111111111111111111111111111111",
+                rightCommit = "2222222222222222222222222222222222222222"
+            )
+        )
+        val items = listOf(
+            WalkthroughItem(
+                text = "Explain changed branch",
+                line = 13,
+                diffId = "popup-change",
+                diffFile = "src/Foo.kt",
+                diffSide = DiffSide.Right
+            )
+        )
+
+        val saved = store.save(
+            description = "Explain PR change",
+            targetKind = WalkthroughTargetKind.Diff,
+            diffDescriptors = descriptors,
+            items = items
+        )
+
+        assertEquals(WalkthroughTargetKind.Diff, saved.targetKind)
+        assertEquals(descriptors, saved.diffDescriptors)
+        assertEquals(items, saved.items)
+        assertEquals(saved, store.load(saved.id))
+    }
+
+    @Test
     fun listSortsNewestFirstAndSkipsCorruptFiles() {
         val corruptFiles = mutableListOf<Path>()
         val store = WalkthroughHistoryStore(

--- a/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughSessionRegistryTest.kt
+++ b/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughSessionRegistryTest.kt
@@ -14,6 +14,8 @@ class WalkthroughSessionRegistryTest {
         WalkthroughSession(
             id = "test-session",
             initialItems = items,
+            targetKind = WalkthroughTargetKind.File,
+            diffDescriptors = emptyList(),
             acceptsQuestions = true
         )
 


### PR DESCRIPTION
## Summary

- Add `show_diff_walkthrough_items` MCP tool for walkthroughs anchored to IDEA diff viewers
- Use Git commit hashes instead of agent-submitted diff text
- Persist diff walkthrough metadata and support replay from history
- Add Git4Idea dependency and diff viewer extension wiring
- Update tool descriptions so agents choose file vs diff walkthroughs appropriately

## Follow-up fixes

- Address Copilot review on `WalkthroughHistoryStore.validateRecord`: require `targetKind == File` ⇔ `diffDescriptors.isEmpty()`, and require each diff descriptor to provide either a non-blank `file` or both non-blank `leftFile` and `rightFile`; covered by new `WalkthroughHistoryStoreTest` cases.
- Address Copilot review on `ShowWalkthroughItemsToolset.parseDiffPayload`: fail fast on empty `diffs` before parsing items, so a payload with items but no diffs returns `diffs must not be empty` instead of a downstream `Unknown diffId`.
- Fix invisible diff popup: defer `attachToViewer` until `editor.contentComponent.isShowing` via a `HierarchyListener` registered with the session disposable. The synchronous attach inside `WalkthroughDiffExtension.onViewerCreated` ran before the diff dialog was on screen, so `SwingUtilities.convertPointToScreen` threw `IllegalComponentStateException` and positioning silently aborted.
- Fix connector arrow flicker in diff walkthroughs: drop the `FileEditorManagerListener` that flipped `connectorHidden = true` whenever the selected text editor's document didn't match the diff viewer's document. Diff viewer editors live in a dialog and aren't tracked by `FileEditorManager`, so the listener was effectively always hiding the arrow as soon as the diff dialog got focus. The equivalent file-walkthrough listener in `WalkthroughOrchestrator` is intentionally left in place.

## Test plan

- [ ] Run a diff walkthrough (e.g. via `just run` and the attached `pr-diff-based-walkthroughs-anchored-to-git-commi-*.json` history record) and confirm the popup appears once the diff dialog opens, anchored to the right side, with the connector arrow visible for the full step.
- [ ] Step forward/back through diff walkthrough items and confirm the popup follows the active side/line without the connector flickering off.
- [ ] Switch focus between the diff dialog and a regular file editor in the same project and confirm the diff popup connector keeps painting while the diff dialog is in front.
