### PR TITLE
fix: stop noisy cancellation errors and warning flashes during agent reconnects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `.github/zizmor.yml` configuration files documenting the intentional exemptions.
 - `verifyPlugin` now runs on every pull request, not just on pushes to `main`.
 
+### Fixed
+
+- The popup no longer briefly flashes the "agent is not listening" warning when the MCP client
+  cancels and immediately re-issues `await_walkthrough_question`. The status now waits for a
+  short grace period (5 s) before flipping. The underlying `CancellationException` is also no
+  longer surfaced to the IDE log as a tool-call error.
+
 ## [0.4.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - The popup no longer briefly flashes the "agent is not listening" warning when the MCP client
   cancels and immediately re-issues `await_walkthrough_question`. The status now waits for a
   short grace period (5 s) before flipping. The underlying `CancellationException` is also no
-  longer surfaced to the IDE log as a tool-call error.
+  longer surfaced to the IDE log as a tool-call error. The inline spinner is now cleared as soon
+  as `insert_walkthrough_tangents` returns, instead of staying on screen until the grace window
+  expires.
 
 ## [0.4.0]
 

--- a/src/main/kotlin/com/forketyfork/walkthrough/ShowWalkthroughItemsToolset.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/ShowWalkthroughItemsToolset.kt
@@ -10,6 +10,7 @@ import com.intellij.mcpserver.mcpFail
 import com.intellij.mcpserver.projectOrNull
 import com.intellij.openapi.application.EDT
 import com.intellij.openapi.project.Project
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.withContext
@@ -186,15 +187,24 @@ class ShowWalkthroughItemsToolset : McpToolset {
         val project = requireProject()
         val registry = WalkthroughSessionRegistry.getInstance(project)
         val session = registry.get(walkthroughId)
-        val result = when {
-            session != null -> resolveAwaitQuestionResult(
-                result = session.awaitQuestionResult(QUESTION_TOOL_REFRESH_TIMEOUT_MILLIS),
-                wasDismissed = registry.consumeDismissed(walkthroughId),
-            )
+        val result = try {
+            when {
+                session != null -> resolveAwaitQuestionResult(
+                    result = session.awaitQuestionResult(QUESTION_TOOL_REFRESH_TIMEOUT_MILLIS),
+                    wasDismissed = registry.consumeDismissed(walkthroughId),
+                )
 
-            registry.consumeDismissed(walkthroughId) -> WalkthroughQuestionAwaitResult.Dismissed
+                registry.consumeDismissed(walkthroughId) -> WalkthroughQuestionAwaitResult.Dismissed
 
-            else -> mcpFail("Unknown walkthroughId: $walkthroughId")
+                else -> mcpFail("Unknown walkthroughId: $walkthroughId")
+            }
+        } catch (@Suppress("SwallowedException") cancellation: CancellationException) {
+            // The MCP client cancelled this tool call (e.g. its own request timeout or disconnect).
+            // The waiter has already been cleaned up by `awaitQuestionResult`'s `finally` block.
+            // Translate the cancellation into a clean, non-error response so it does not surface
+            // as a JobCancellationException in the IDE log. Treat it like a refresh timeout so the
+            // agent immediately re-issues the call on its next turn.
+            WalkthroughQuestionAwaitResult.WaitingExpired
         }
         return when (result) {
             is WalkthroughQuestionAwaitResult.Received -> {

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughSessionRegistry.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughSessionRegistry.kt
@@ -7,6 +7,9 @@ import androidx.compose.runtime.snapshots.SnapshotStateList
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.project.Project
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -41,12 +44,14 @@ private data class WalkthroughQuestionWaitRegistration(
     val immediateResult: WalkthroughQuestionAwaitResult?,
 )
 
+@Suppress("TooManyFunctions")
 class WalkthroughSession internal constructor(
     val id: String,
     initialItems: List<WalkthroughItem>,
     val targetKind: WalkthroughTargetKind,
     val diffDescriptors: List<DiffWalkthroughDescriptor>,
     internal val acceptsQuestions: Boolean,
+    internal val notListeningGracePeriodMillis: Long = DEFAULT_NOT_LISTENING_GRACE_PERIOD_MILLIS,
 ) {
     internal val items: SnapshotStateList<WalkthroughItem> =
         mutableStateListOf<WalkthroughItem>().apply { addAll(initialItems) }
@@ -59,6 +64,8 @@ class WalkthroughSession internal constructor(
     private var pendingQuestion: WalkthroughTangentQuestion? = null
     private var inFlightQuestion: WalkthroughTangentQuestion? = null
     private val disposed = CompletableDeferred<Unit>()
+    private val sessionScope = CoroutineScope(SupervisorJob())
+    private var pendingNotListeningJob: Job? = null
 
     fun snapshotItems(): List<WalkthroughItem> = items.toList()
 
@@ -79,12 +86,14 @@ class WalkthroughSession internal constructor(
                     activeQuestionWaiter.also {
                         activeQuestionWaiter = null
                         inFlightQuestion = question
+                        cancelPendingAgentNotWaitingLocked()
                         setQuestionStatus(WalkthroughQuestionStatus.ProcessingQuestion)
                     }
                 }
 
                 else -> {
                     pendingQuestion = question
+                    cancelPendingAgentNotWaitingLocked()
                     setQuestionStatus(WalkthroughQuestionStatus.QuestionQueued)
                     null
                 }
@@ -145,7 +154,7 @@ class WalkthroughSession internal constructor(
         currentIndexState.intValue = lastSubtreeIndex + 1
         synchronized(questionLock) {
             inFlightQuestion = null
-            setQuestionStatus(WalkthroughQuestionStatus.AgentNotWaiting)
+            scheduleAgentNotWaitingLocked()
         }
         return labeled
     }
@@ -157,10 +166,12 @@ class WalkthroughSession internal constructor(
                     activeQuestionWaiter = null
                     pendingQuestion = null
                     inFlightQuestion = null
+                    cancelPendingAgentNotWaitingLocked()
                     setQuestionStatus(WalkthroughQuestionStatus.AgentNotWaiting)
                 }
             }
             waiter?.result?.complete(WalkthroughQuestionAwaitResult.Dismissed)
+            sessionScope.coroutineContext[Job]?.cancel()
         }
     }
 
@@ -175,6 +186,7 @@ class WalkthroughSession internal constructor(
                 )
 
                 inFlightQuestion != null -> {
+                    cancelPendingAgentNotWaitingLocked()
                     setQuestionStatus(WalkthroughQuestionStatus.ProcessingQuestion)
                     WalkthroughQuestionWaitRegistration(
                         waiter = null,
@@ -187,6 +199,7 @@ class WalkthroughSession internal constructor(
                     val question = pendingQuestion
                     pendingQuestion = null
                     inFlightQuestion = question
+                    cancelPendingAgentNotWaitingLocked()
                     setQuestionStatus(WalkthroughQuestionStatus.ProcessingQuestion)
                     WalkthroughQuestionWaitRegistration(
                         waiter = null,
@@ -198,6 +211,7 @@ class WalkthroughSession internal constructor(
                 else -> {
                     val previousWaiter = activeQuestionWaiter
                     activeQuestionWaiter = waiter
+                    cancelPendingAgentNotWaitingLocked()
                     setQuestionStatus(WalkthroughQuestionStatus.WaitingForQuestion)
                     WalkthroughQuestionWaitRegistration(
                         waiter = waiter,
@@ -213,7 +227,7 @@ class WalkthroughSession internal constructor(
         val expired = synchronized(questionLock) {
             if (activeQuestionWaiter === waiter) {
                 activeQuestionWaiter = null
-                setQuestionStatus(WalkthroughQuestionStatus.AgentNotWaiting)
+                scheduleAgentNotWaitingLocked()
                 true
             } else {
                 false
@@ -228,7 +242,7 @@ class WalkthroughSession internal constructor(
         synchronized(questionLock) {
             if (activeQuestionWaiter === waiter) {
                 activeQuestionWaiter = null
-                setQuestionStatus(WalkthroughQuestionStatus.AgentNotWaiting)
+                scheduleAgentNotWaitingLocked()
             }
         }
     }
@@ -236,6 +250,50 @@ class WalkthroughSession internal constructor(
     private fun setQuestionStatus(status: WalkthroughQuestionStatus) {
         questionStatusState.value = status
         loadingState.value = status == WalkthroughQuestionStatus.ProcessingQuestion
+    }
+
+    /**
+     * Defers the transition to [WalkthroughQuestionStatus.AgentNotWaiting] by [notListeningGracePeriodMillis]
+     * to avoid briefly showing the "agent is not listening" warning when the MCP client cancels and
+     * immediately re-issues the await call. Must be invoked while holding [questionLock].
+     */
+    private fun scheduleAgentNotWaitingLocked() {
+        cancelPendingAgentNotWaitingLocked()
+        if (notListeningGracePeriodMillis <= 0L) {
+            setQuestionStatus(WalkthroughQuestionStatus.AgentNotWaiting)
+            return
+        }
+        lateinit var scheduledJob: Job
+        scheduledJob = sessionScope.launch {
+            delay(notListeningGracePeriodMillis)
+            synchronized(questionLock) { applyPendingAgentNotWaitingLocked(scheduledJob) }
+        }
+        pendingNotListeningJob = scheduledJob
+    }
+
+    /** Must be invoked while holding [questionLock]. */
+    private fun applyPendingAgentNotWaitingLocked(scheduledJob: Job) {
+        if (pendingNotListeningJob !== scheduledJob) return
+        val hasListener = activeQuestionWaiter != null || inFlightQuestion != null || pendingQuestion != null
+        if (!hasListener) {
+            setQuestionStatus(WalkthroughQuestionStatus.AgentNotWaiting)
+        }
+        pendingNotListeningJob = null
+    }
+
+    /** Must be invoked while holding [questionLock]. */
+    private fun cancelPendingAgentNotWaitingLocked() {
+        pendingNotListeningJob?.cancel()
+        pendingNotListeningJob = null
+    }
+
+    internal companion object {
+        /**
+         * How long to wait after the agent stops listening before flipping the popup to
+         * [WalkthroughQuestionStatus.AgentNotWaiting]. MCP clients typically reconnect within
+         * milliseconds; the grace period avoids a visible warning flash during normal retries.
+         */
+        const val DEFAULT_NOT_LISTENING_GRACE_PERIOD_MILLIS: Long = 5_000L
     }
 }
 

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughSessionRegistry.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughSessionRegistry.kt
@@ -255,7 +255,9 @@ class WalkthroughSession internal constructor(
     /**
      * Defers the transition to [WalkthroughQuestionStatus.AgentNotWaiting] by [notListeningGracePeriodMillis]
      * to avoid briefly showing the "agent is not listening" warning when the MCP client cancels and
-     * immediately re-issues the await call. Must be invoked while holding [questionLock].
+     * immediately re-issues the await call. The spinner ([loadingState]) is cleared immediately so it
+     * does not keep spinning during the grace window after the question has actually been answered.
+     * Must be invoked while holding [questionLock].
      */
     private fun scheduleAgentNotWaitingLocked() {
         cancelPendingAgentNotWaitingLocked()
@@ -263,6 +265,9 @@ class WalkthroughSession internal constructor(
             setQuestionStatus(WalkthroughQuestionStatus.AgentNotWaiting)
             return
         }
+        // Stop the spinner now even though the visible status text is deferred: the question is
+        // done, only the AgentNotWaiting warning flash needs the grace window.
+        loadingState.value = false
         lateinit var scheduledJob: Job
         scheduledJob = sessionScope.launch {
             delay(notListeningGracePeriodMillis)

--- a/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughSessionRegistryTest.kt
+++ b/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughSessionRegistryTest.kt
@@ -15,10 +15,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class WalkthroughSessionRegistryTest {
-    private fun newSession(
-        items: List<WalkthroughItem>,
-        notListeningGracePeriodMillis: Long = 0L,
-    ) = WalkthroughSession(
+    private fun newSession(items: List<WalkthroughItem>, notListeningGracePeriodMillis: Long = 0L) = WalkthroughSession(
         id = "test-session",
         initialItems = items,
         targetKind = WalkthroughTargetKind.File,
@@ -245,7 +242,7 @@ class WalkthroughSessionRegistryTest {
     @Test
     fun cancelledAwaitClearsWaiterAndAllowsFreshAwait() = runBlocking {
         val session = newSession(
-            assignTopLevelLabels(listOf(WalkthroughItem(text = "only")))
+            assignTopLevelLabels(listOf(WalkthroughItem(text = "only"))),
         )
 
         val firstAwait = async { session.awaitQuestionResult(timeoutMillis = TEST_AWAIT_TIMEOUT_MILLIS) }
@@ -265,7 +262,7 @@ class WalkthroughSessionRegistryTest {
         assertTrue(secondResult is WalkthroughQuestionAwaitResult.Received)
         assertEquals(
             "after cancel",
-            (secondResult as WalkthroughQuestionAwaitResult.Received).question.question
+            (secondResult as WalkthroughQuestionAwaitResult.Received).question.question,
         )
     }
 
@@ -273,7 +270,7 @@ class WalkthroughSessionRegistryTest {
     fun reconnectWithinGraceWindowAvoidsAgentNotWaitingFlash() = runBlocking {
         val session = newSession(
             items = assignTopLevelLabels(listOf(WalkthroughItem(text = "only"))),
-            notListeningGracePeriodMillis = TEST_GRACE_PERIOD_MILLIS
+            notListeningGracePeriodMillis = TEST_GRACE_PERIOD_MILLIS,
         )
 
         val firstAwait = async { session.awaitQuestionResult(timeoutMillis = TEST_AWAIT_TIMEOUT_MILLIS) }
@@ -297,7 +294,7 @@ class WalkthroughSessionRegistryTest {
     fun graceWindowExpiringWithoutReconnectFlipsToAgentNotWaiting() = runBlocking {
         val session = newSession(
             items = assignTopLevelLabels(listOf(WalkthroughItem(text = "only"))),
-            notListeningGracePeriodMillis = TEST_GRACE_PERIOD_MILLIS
+            notListeningGracePeriodMillis = TEST_GRACE_PERIOD_MILLIS,
         )
 
         val firstAwait = async { session.awaitQuestionResult(timeoutMillis = TEST_AWAIT_TIMEOUT_MILLIS) }
@@ -312,7 +309,7 @@ class WalkthroughSessionRegistryTest {
     fun insertTangentsClearsLoadingImmediatelyDuringGraceWindow() = runBlocking {
         val session = newSession(
             items = assignTopLevelLabels(listOf(WalkthroughItem(text = "only"))),
-            notListeningGracePeriodMillis = LONG_GRACE_PERIOD_MILLIS
+            notListeningGracePeriodMillis = LONG_GRACE_PERIOD_MILLIS,
         )
         session.submitQuestion("explain")
         val received = session.awaitQuestionResult(timeoutMillis = TEST_AWAIT_TIMEOUT_MILLIS)

--- a/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughSessionRegistryTest.kt
+++ b/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughSessionRegistryTest.kt
@@ -1,7 +1,9 @@
 package com.forketyfork.walkthrough
 
 import com.intellij.openapi.Disposable
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.yield
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -13,12 +15,16 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class WalkthroughSessionRegistryTest {
-    private fun newSession(items: List<WalkthroughItem>) = WalkthroughSession(
+    private fun newSession(
+        items: List<WalkthroughItem>,
+        notListeningGracePeriodMillis: Long = 0L,
+    ) = WalkthroughSession(
         id = "test-session",
         initialItems = items,
         targetKind = WalkthroughTargetKind.File,
         diffDescriptors = emptyList(),
         acceptsQuestions = true,
+        notListeningGracePeriodMillis = notListeningGracePeriodMillis,
     )
 
     @Test
@@ -237,6 +243,72 @@ class WalkthroughSessionRegistryTest {
     }
 
     @Test
+    fun cancelledAwaitClearsWaiterAndAllowsFreshAwait() = runBlocking {
+        val session = newSession(
+            assignTopLevelLabels(listOf(WalkthroughItem(text = "only")))
+        )
+
+        val firstAwait = async { session.awaitQuestionResult(timeoutMillis = TEST_AWAIT_TIMEOUT_MILLIS) }
+        waitUntilQuestionStatus(session, WalkthroughQuestionStatus.WaitingForQuestion)
+        firstAwait.cancel()
+        assertThrows(CancellationException::class.java) { runBlocking { firstAwait.await() } }
+
+        // After the cancelled coroutine's `finally` runs, the waiter must be cleared so a fresh
+        // `awaitQuestionResult` is not reported as `Replaced` and a new question is delivered.
+        waitUntilQuestionStatus(session, WalkthroughQuestionStatus.AgentNotWaiting)
+
+        val secondAwait = async { session.awaitQuestionResult(timeoutMillis = TEST_AWAIT_TIMEOUT_MILLIS) }
+        waitUntilQuestionStatus(session, WalkthroughQuestionStatus.WaitingForQuestion)
+        session.submitQuestion("after cancel")
+        val secondResult = secondAwait.await()
+
+        assertTrue(secondResult is WalkthroughQuestionAwaitResult.Received)
+        assertEquals(
+            "after cancel",
+            (secondResult as WalkthroughQuestionAwaitResult.Received).question.question
+        )
+    }
+
+    @Test
+    fun reconnectWithinGraceWindowAvoidsAgentNotWaitingFlash() = runBlocking {
+        val session = newSession(
+            items = assignTopLevelLabels(listOf(WalkthroughItem(text = "only"))),
+            notListeningGracePeriodMillis = TEST_GRACE_PERIOD_MILLIS
+        )
+
+        val firstAwait = async { session.awaitQuestionResult(timeoutMillis = TEST_AWAIT_TIMEOUT_MILLIS) }
+        waitUntilQuestionStatus(session, WalkthroughQuestionStatus.WaitingForQuestion)
+        firstAwait.cancel()
+        assertThrows(CancellationException::class.java) { runBlocking { firstAwait.await() } }
+
+        // The status must NOT immediately flip to AgentNotWaiting — the grace window protects it.
+        assertEquals(WalkthroughQuestionStatus.WaitingForQuestion, session.questionStatusState.value)
+
+        // Reconnect within the grace window and verify the popup never showed AgentNotWaiting.
+        val secondAwait = async { session.awaitQuestionResult(timeoutMillis = TEST_AWAIT_TIMEOUT_MILLIS) }
+        waitUntilQuestionStatus(session, WalkthroughQuestionStatus.WaitingForQuestion)
+        assertEquals(WalkthroughQuestionStatus.WaitingForQuestion, session.questionStatusState.value)
+
+        secondAwait.cancel()
+        assertThrows(CancellationException::class.java) { runBlocking { secondAwait.await() } }
+    }
+
+    @Test
+    fun graceWindowExpiringWithoutReconnectFlipsToAgentNotWaiting() = runBlocking {
+        val session = newSession(
+            items = assignTopLevelLabels(listOf(WalkthroughItem(text = "only"))),
+            notListeningGracePeriodMillis = TEST_GRACE_PERIOD_MILLIS
+        )
+
+        val firstAwait = async { session.awaitQuestionResult(timeoutMillis = TEST_AWAIT_TIMEOUT_MILLIS) }
+        waitUntilQuestionStatus(session, WalkthroughQuestionStatus.WaitingForQuestion)
+        firstAwait.cancel()
+        assertThrows(CancellationException::class.java) { runBlocking { firstAwait.await() } }
+
+        waitUntilQuestionStatus(session, WalkthroughQuestionStatus.AgentNotWaiting)
+    }
+
+    @Test
     fun newAwaitReplacesPreviousWaiter() = runBlocking {
         val session = newSession(
             assignTopLevelLabels(listOf(WalkthroughItem(text = "only"))),
@@ -300,6 +372,7 @@ class WalkthroughSessionRegistryTest {
         repeat(TEST_STATUS_WAIT_ATTEMPTS) {
             if (session.questionStatusState.value == status) return
             yield()
+            delay(TEST_STATUS_POLL_INTERVAL_MILLIS)
         }
         assertEquals(status, session.questionStatusState.value)
     }
@@ -307,5 +380,7 @@ class WalkthroughSessionRegistryTest {
     private companion object {
         const val TEST_AWAIT_TIMEOUT_MILLIS = 1_000L
         const val TEST_STATUS_WAIT_ATTEMPTS = 100
+        const val TEST_STATUS_POLL_INTERVAL_MILLIS = 10L
+        const val TEST_GRACE_PERIOD_MILLIS = 50L
     }
 }

--- a/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughSessionRegistryTest.kt
+++ b/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughSessionRegistryTest.kt
@@ -309,6 +309,25 @@ class WalkthroughSessionRegistryTest {
     }
 
     @Test
+    fun insertTangentsClearsLoadingImmediatelyDuringGraceWindow() = runBlocking {
+        val session = newSession(
+            items = assignTopLevelLabels(listOf(WalkthroughItem(text = "only"))),
+            notListeningGracePeriodMillis = LONG_GRACE_PERIOD_MILLIS
+        )
+        session.submitQuestion("explain")
+        val received = session.awaitQuestionResult(timeoutMillis = TEST_AWAIT_TIMEOUT_MILLIS)
+        assertTrue(received is WalkthroughQuestionAwaitResult.Received)
+        assertEquals(true, session.loadingState.value)
+
+        session.insertTangents("1", listOf(WalkthroughItem(text = "answer")))
+
+        // The spinner must stop immediately; only the AgentNotWaiting warning is deferred by the grace window.
+        assertEquals(false, session.loadingState.value)
+        // The grace window is much longer than this check, so the visible status flip is still pending.
+        assertEquals(WalkthroughQuestionStatus.ProcessingQuestion, session.questionStatusState.value)
+    }
+
+    @Test
     fun newAwaitReplacesPreviousWaiter() = runBlocking {
         val session = newSession(
             assignTopLevelLabels(listOf(WalkthroughItem(text = "only"))),
@@ -382,5 +401,6 @@ class WalkthroughSessionRegistryTest {
         const val TEST_STATUS_WAIT_ATTEMPTS = 100
         const val TEST_STATUS_POLL_INTERVAL_MILLIS = 10L
         const val TEST_GRACE_PERIOD_MILLIS = 50L
+        const val LONG_GRACE_PERIOD_MILLIS = 10_000L
     }
 }


### PR DESCRIPTION
## Solution

While the agent was connected to the popup via `await_walkthrough_question`, the MCP client periodically cancelled and immediately re-issued the call. That left two visible artifacts:

- a `kotlinx.coroutines.JobCancellationException` showing up in the IDE log as a tool-call error, and
- the popup briefly flashing the "agent is not listening" warning before the agent reconnected.

This PR addresses both:

- `ShowWalkthroughItemsToolset.awaitWalkthroughQuestion` now catches `CancellationException` and returns a clean `waiting-expired` response, so cancellations never reach the IDE as MCP tool errors. The waiter is already cleaned up by `awaitQuestionResult`'s `finally` block, so the next call gets a fresh waiter.
- `WalkthroughSession` defers the transition to `AgentNotWaiting` by a configurable grace period (default 5 s) via a session-scoped coroutine. A new waiter, a queued/in-flight question, or `dismiss()` cancels the pending flip immediately, so the warning only appears if the agent really stays gone.
- A new `notListeningGracePeriodMillis` constructor parameter lets tests opt into immediate or short-window behavior.

## Test plan

- [ ] Start a walkthrough, connect an MCP agent via `await_walkthrough_question`, and let it run long enough for at least one client-side cancel/reconnect cycle. Confirm the popup no longer flashes the "agent is not listening" warning and the IDE log no longer shows `JobCancellationException` from `tools/call`.
- [ ] Stop the agent without reconnecting and confirm the popup transitions to the "agent is not listening" state after ~5 s.
- [ ] While the popup shows the warning, restart the agent and confirm follow-up questions still flow through.

## Issue linkage

No tracking issue exists for this fix — this is a hotfix fast-path PR. Issue linkage will be added during mandatory cleanup if one is filed retroactively.
