### PR TITLE
fix(walkthrough): reuse open diff viewer instead of opening a new tab

### DIFF
--- a/src/main/kotlin/com/forketyfork/walkthrough/DiffWalkthroughSession.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/DiffWalkthroughSession.kt
@@ -223,6 +223,10 @@ private class DiffWalkthroughController(
         applyPopupGeometryForItem(popup, editor, popupItem)
     }
 
+    // Called from [createActiveViewerCleanup] via `WeakReference<DiffWalkthroughController>.get()?.…`.
+    // Qodana's UnusedSymbol inspection can't resolve the call target through the weak reference
+    // (the generic is erased to `Object?`), so it flags the function as unused — suppress here.
+    @Suppress("unused")
     fun clearActiveViewerIfMatches(viewer: FrameDiffTool.DiffViewer) {
         if (activeViewer === viewer) {
             activeViewer = null

--- a/src/main/kotlin/com/forketyfork/walkthrough/DiffWalkthroughSession.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/DiffWalkthroughSession.kt
@@ -155,6 +155,8 @@ private class DiffWalkthroughController(
     private val currentEditorUpdater: (Editor) -> Unit
 ) {
     private var pendingNavigationId = 0
+    private var activeViewer: FrameDiffTool.DiffViewer? = null
+    private var activeDescriptorId: String? = null
 
     fun scheduleItemNavigation(item: WalkthroughItem) {
         pendingNavigationId += 1
@@ -169,11 +171,27 @@ private class DiffWalkthroughController(
 
     fun attachToViewer(viewer: FrameDiffTool.DiffViewer, item: WalkthroughItem) {
         if (sessionDisposable.isDisposed || viewer !is EditorDiffViewer) return
+        trackActiveViewer(viewer, resolveDescriptor(item)?.id)
         val editor = selectEditor(viewer, item.diffSide ?: DiffSide.Right)
         val popup = popupProvider()
         if (editor != null && popup != null) {
             attachWhenShowing(popup, editor, item)
         }
+    }
+
+    private fun trackActiveViewer(viewer: FrameDiffTool.DiffViewer, descriptorId: String?) {
+        activeDescriptorId = descriptorId
+        if (activeViewer === viewer) return
+        activeViewer = viewer
+        Disposer.register(
+            viewer,
+            Disposable {
+                if (activeViewer === viewer) {
+                    activeViewer = null
+                    activeDescriptorId = null
+                }
+            }
+        )
     }
 
     private fun attachWhenShowing(popup: WalkthroughPopupSurface, editor: Editor, item: WalkthroughItem) {
@@ -215,6 +233,11 @@ private class DiffWalkthroughController(
 
     private fun showItem(item: WalkthroughItem) {
         val descriptor = resolveDescriptor(item) ?: return
+        val existing = activeViewer
+        if (existing != null && !Disposer.isDisposed(existing) && activeDescriptorId == descriptor.id) {
+            attachToViewer(existing, item)
+            return
+        }
         DiffManager.getInstance().showDiff(
             project,
             SimpleDiffRequestChain.fromProducer(

--- a/src/main/kotlin/com/forketyfork/walkthrough/DiffWalkthroughSession.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/DiffWalkthroughSession.kt
@@ -32,6 +32,7 @@ import git4idea.GitContentRevision
 import git4idea.GitRevisionNumber
 import java.awt.event.HierarchyEvent
 import java.awt.event.HierarchyListener
+import java.lang.ref.WeakReference
 import javax.swing.SwingUtilities
 import com.intellij.diff.util.Side as PlatformDiffSide
 
@@ -175,15 +176,14 @@ private class DiffWalkthroughController(
         activeDescriptorId = descriptorId
         if (activeViewer === viewer) return
         activeViewer = viewer
-        Disposer.register(
-            viewer,
-            Disposable {
-                if (activeViewer === viewer) {
-                    activeViewer = null
-                    activeDescriptorId = null
-                }
-            }
-        )
+        // Avoid capturing `this` strongly inside the viewer-owned disposable: the diff viewer may
+        // outlive the walkthrough session, and a strong reference would keep the whole controller
+        // graph (session disposable, popup state, etc.) reachable until the diff tab is closed.
+        val cleanup = createActiveViewerCleanup(WeakReference(this), viewer)
+        Disposer.register(viewer, cleanup)
+        // Also dispose the cleanup when the session ends so the references held by the cleanup
+        // disposable itself are released even if the diff viewer remains open.
+        Disposer.register(sessionDisposable, cleanup)
     }
 
     private fun attachWhenShowing(popup: WalkthroughPopupSurface, editor: Editor, item: WalkthroughItem) {
@@ -223,10 +223,17 @@ private class DiffWalkthroughController(
         applyPopupGeometryForItem(popup, editor, popupItem)
     }
 
+    fun clearActiveViewerIfMatches(viewer: FrameDiffTool.DiffViewer) {
+        if (activeViewer === viewer) {
+            activeViewer = null
+            activeDescriptorId = null
+        }
+    }
+
     private fun showItem(item: WalkthroughItem) {
         val descriptor = resolveDescriptor(item) ?: return
         val existing = activeViewer
-        if (existing != null && !Disposer.isDisposed(existing) && activeDescriptorId == descriptor.id) {
+        if (existing != null && !existing.isViewerDisposed() && activeDescriptorId == descriptor.id) {
             attachToViewer(existing, item)
             return
         }
@@ -262,6 +269,27 @@ private class DiffWalkthroughController(
         }
     }
 }
+
+/**
+ * Creates a [Disposable] that clears the controller's reference to [viewer] when either the viewer
+ * or the walkthrough session is disposed. The controller is held weakly so a still-open diff viewer
+ * cannot keep the walkthrough session graph reachable after the session itself has been closed.
+ */
+private fun createActiveViewerCleanup(
+    controllerRef: WeakReference<DiffWalkthroughController>,
+    viewer: FrameDiffTool.DiffViewer,
+): Disposable = Disposable {
+    controllerRef.get()?.clearActiveViewerIfMatches(viewer)
+    controllerRef.clear()
+}
+
+/**
+ * Non-deprecated replacement for `Disposer.isDisposed(disposable)`: relies on [CheckedDisposable]
+ * when the viewer implements it. If the viewer doesn't expose its disposal state we conservatively
+ * treat it as not disposed; in that case the viewer-owned cleanup callback above will clear
+ * `activeViewer` once the platform actually disposes the viewer.
+ */
+private fun FrameDiffTool.DiffViewer.isViewerDisposed(): Boolean = (this as? CheckedDisposable)?.isDisposed == true
 
 private class DiffWalkthroughRequestProducer(
     private val project: Project,


### PR DESCRIPTION
When navigating between walkthrough items that target the same diff
descriptor, the controller now reattaches the popup to the already-open
diff viewer instead of opening a new diff tab/dialog through
DiffManager.showDiff. The active viewer reference is cleared when the
viewer is disposed, so closing the diff and stepping again still opens
a fresh viewer.