### PR TITLE
fix: persist inserted tangents to walkthrough history (#34)

### DIFF
--- a/src/main/kotlin/com/forketyfork/walkthrough/ShowWalkthroughItemsToolset.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/ShowWalkthroughItemsToolset.kt
@@ -98,6 +98,7 @@ class ShowWalkthroughItemsToolset : McpToolset {
 
         val record = WalkthroughHistoryService.getInstance(project)
             .save(trimmedDescription, session.snapshotItems())
+        session.historyRecordId = record?.id
 
         val labels = labeledItems.mapNotNull { it.label }.joinToString(", ")
         val historySuffix = record
@@ -158,6 +159,7 @@ class ShowWalkthroughItemsToolset : McpToolset {
             diffDescriptors = parsedPayload.descriptors,
             items = session.snapshotItems(),
         )
+        session.historyRecordId = record?.id
 
         val labels = labeledItems.mapNotNull { it.label }.joinToString(", ")
         val historySuffix = record
@@ -259,6 +261,9 @@ class ShowWalkthroughItemsToolset : McpToolset {
 
         val inserted = withContext(Dispatchers.EDT) {
             session.insertTangents(trimmedParent, parsedItems)
+        }
+        session.historyRecordId?.let { recordId ->
+            WalkthroughHistoryService.getInstance(project).updateItems(recordId, session.snapshotItems())
         }
         val labels = inserted.mapNotNull { it.label }.joinToString(", ")
         return "Inserted ${inserted.size} tangent step(s) under $trimmedParent: $labels"

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughHistoryService.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughHistoryService.kt
@@ -40,6 +40,16 @@ class WalkthroughHistoryService(private val project: Project) {
             store?.load(id)
         }
 
+    fun updateItems(recordId: String, items: List<WalkthroughItem>): WalkthroughRecord? =
+        runHistoryOperation(operation = "update walkthrough history", fallback = null) {
+            store?.let { backing ->
+                val existing = backing.load(recordId) ?: return@let null
+                val updated = existing.copy(items = items)
+                backing.save(updated)
+                updated
+            }
+        }
+
     private fun <T> runHistoryOperation(operation: String, fallback: T, block: () -> T): T =
         runCatching(block).getOrElse { exception ->
             LOG.warn("Failed to $operation", exception)

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughSessionRegistry.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughSessionRegistry.kt
@@ -59,6 +59,9 @@ class WalkthroughSession internal constructor(
     internal val questionStatusState = mutableStateOf(WalkthroughQuestionStatus.AgentNotWaiting)
     internal val loadingState = mutableStateOf(false)
 
+    @Volatile
+    var historyRecordId: String? = null
+
     private val questionLock = Any()
     private var activeQuestionWaiter: WalkthroughQuestionWaiter? = null
     private var pendingQuestion: WalkthroughTangentQuestion? = null

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughSessionRegistry.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughSessionRegistry.kt
@@ -60,7 +60,7 @@ class WalkthroughSession internal constructor(
     internal val loadingState = mutableStateOf(false)
 
     @Volatile
-    var historyRecordId: String? = null
+    internal var historyRecordId: String? = null
 
     private val questionLock = Any()
     private var activeQuestionWaiter: WalkthroughQuestionWaiter? = null

--- a/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughHistoryStoreTest.kt
+++ b/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughHistoryStoreTest.kt
@@ -194,6 +194,84 @@ class WalkthroughHistoryStoreTest {
     }
 
     @Test
+    fun resavingFileRecordWithSameIdReplacesItemsAndPreservesMetadata() {
+        val store = WalkthroughHistoryStore(
+            directory = tempDir,
+            clock = Clock.fixed(Instant.parse("2026-05-09T04:34:00Z"), ZoneOffset.UTC),
+            randomSuffix = { "abc12345" },
+        )
+        val initialItems = listOf(
+            WalkthroughItem(text = "step one", label = "1"),
+            WalkthroughItem(text = "step two", label = "2"),
+        )
+        val saved = store.save("Persisted tangents", initialItems)
+
+        val updatedItems = listOf(
+            WalkthroughItem(text = "step one", label = "1"),
+            WalkthroughItem(text = "step two", label = "2"),
+            WalkthroughItem(text = "answer A", label = "2.1", parentLabel = "2"),
+        )
+        store.save(saved.copy(items = updatedItems))
+
+        val reloaded = store.load(saved.id)
+        assertEquals(updatedItems, reloaded?.items)
+        assertEquals(saved.id, reloaded?.id)
+        assertEquals(saved.createdAt, reloaded?.createdAt)
+        assertEquals(saved.description, reloaded?.description)
+        assertEquals(saved.targetKind, reloaded?.targetKind)
+        assertEquals(saved.diffDescriptors, reloaded?.diffDescriptors)
+    }
+
+    @Test
+    fun resavingDiffRecordWithSameIdReplacesItemsAndPreservesDescriptors() {
+        val store = WalkthroughHistoryStore(
+            directory = tempDir,
+            clock = Clock.fixed(Instant.parse("2026-05-09T04:34:00Z"), ZoneOffset.UTC),
+            randomSuffix = { "abc12345" },
+        )
+        val descriptors = listOf(
+            DiffWalkthroughDescriptor(
+                id = "popup-change",
+                file = "src/Foo.kt",
+                leftCommit = "1111111111111111111111111111111111111111",
+                rightCommit = "2222222222222222222222222222222222222222",
+            ),
+        )
+        val initialItems = listOf(
+            WalkthroughItem(
+                text = "step one",
+                line = 13,
+                diffId = "popup-change",
+                diffFile = "src/Foo.kt",
+                diffSide = DiffSide.Right,
+                label = "1",
+            ),
+        )
+        val saved = store.save(
+            description = "Diff tangents",
+            targetKind = WalkthroughTargetKind.Diff,
+            diffDescriptors = descriptors,
+            items = initialItems,
+        )
+
+        val updatedItems = initialItems + WalkthroughItem(
+            text = "answer A",
+            line = 20,
+            diffId = "popup-change",
+            diffFile = "src/Foo.kt",
+            diffSide = DiffSide.Right,
+            label = "1.1",
+            parentLabel = "1",
+        )
+        store.save(saved.copy(items = updatedItems))
+
+        val reloaded = store.load(saved.id)
+        assertEquals(updatedItems, reloaded?.items)
+        assertEquals(descriptors, reloaded?.diffDescriptors)
+        assertEquals(WalkthroughTargetKind.Diff, reloaded?.targetKind)
+    }
+
+    @Test
     fun saveAcceptsDiffDescriptorWithOnlySideFiles() {
         val store = WalkthroughHistoryStore(
             directory = tempDir,


### PR DESCRIPTION
Closes #34

## Solution

Child steps inserted via `insert_walkthrough_tangents` appeared in the live walkthrough session but were never written back to `.idea/walkthroughs/<id>.json`. Reopening the walkthrough from history restored only the original top-level steps from the initial `show_walkthrough_items` call.

The live `WalkthroughSession` now tracks the id of the record it was saved under. After each successful `insertTangents` the toolset re-saves the record's items through a new `WalkthroughHistoryService.updateItems` helper that loads the existing record, copies it with the post-insert snapshot, and writes it back. The existing atomic `save()` already overwrites by id, so descriptors and metadata are preserved without extra machinery, and a failed history write is logged through `runHistoryOperation` rather than breaking the active MCP flow.

Both file and diff walkthroughs are covered: the diff entry point sets the record id the same way, and the update path preserves `targetKind` and `diffDescriptors`.

## Test plan

- [ ] Start a walkthrough with `show_walkthrough_items`, ask a question via the popup, let the agent call `insert_walkthrough_tangents`, dismiss the popup, reopen the walkthrough from history, and confirm the inserted child steps are present in their original positions with their hierarchical labels.
- [ ] Repeat the same flow against `show_diff_walkthrough_items` to confirm diff walkthroughs persist tangents and still anchor to the original diff descriptors after reopen.
