### PR TITLE
feat: export saved walkthroughs to Markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - A **Tools → Walkthrough → Export Walkthrough to Markdown…** action that saves any walkthrough from
   the project history as a shareable Markdown document, with each step (and its follow-up answer
-  steps) rendered as a section linked to its source location.
+  steps) rendered as a section annotated with its source location (PR #37).
 
 ## [0.4.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- A **Tools → Walkthrough → Export Walkthrough to Markdown…** action that saves any walkthrough from
+  the project history as a shareable Markdown document, with each step (and its follow-up answer
+  steps) rendered as a section linked to its source location.
+
 ## [0.4.1]
 
 ### Added

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughExportAction.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughExportAction.kt
@@ -58,6 +58,7 @@ private fun exportWalkthrough(project: Project, record: WalkthroughRecord, dataC
     val caught = failure
     when {
         saved != null -> FileEditorManager.getInstance(project).openFile(saved, true)
+
         caught != null -> {
             LOG.warn("Failed to export walkthrough to Markdown", caught)
             JBPopupFactory.getInstance()

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughExportAction.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughExportAction.kt
@@ -1,0 +1,70 @@
+package com.forketyfork.walkthrough
+
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.fileChooser.FileChooserFactory
+import com.intellij.openapi.fileChooser.FileSaverDescriptor
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.popup.JBPopupFactory
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.openapi.vfs.VirtualFile
+import java.io.IOException
+
+class WalkthroughExportAction : AnAction() {
+    override fun update(event: AnActionEvent) {
+        event.presentation.isEnabledAndVisible = event.project != null
+    }
+
+    override fun actionPerformed(event: AnActionEvent) {
+        val project = event.project ?: return
+        showWalkthroughHistoryPopup(project, event.dataContext, "Export Walkthrough to Markdown") { record ->
+            exportWalkthrough(project, record, event.dataContext)
+        }
+    }
+}
+
+private fun exportWalkthrough(project: Project, record: WalkthroughRecord, dataContext: DataContext) {
+    val markdown = renderWalkthroughMarkdown(record)
+    val descriptor = FileSaverDescriptor(
+        "Export Walkthrough to Markdown",
+        "Save the selected walkthrough as a Markdown document",
+        "md",
+    )
+    val dialog = FileChooserFactory.getInstance().createSaveFileDialog(descriptor, project)
+    val baseDir = project.basePath?.let { basePath -> LocalFileSystem.getInstance().findFileByPath(basePath) }
+    val defaultName = "${slugifyDescription(record.description).ifBlank { "walkthrough" }}.md"
+    val wrapper = dialog.save(baseDir, defaultName) ?: return
+
+    var exportedFile: VirtualFile? = null
+    var failure: IOException? = null
+    ApplicationManager.getApplication().runWriteAction {
+        try {
+            val file = wrapper.getVirtualFile(true)
+            if (file != null) {
+                VfsUtil.saveText(file, markdown)
+                exportedFile = file
+            }
+        } catch (exception: IOException) {
+            failure = exception
+        }
+    }
+
+    val saved = exportedFile
+    val caught = failure
+    when {
+        saved != null -> FileEditorManager.getInstance(project).openFile(saved, true)
+        caught != null -> {
+            LOG.warn("Failed to export walkthrough to Markdown", caught)
+            JBPopupFactory.getInstance()
+                .createMessage("Failed to export walkthrough: ${caught.message}")
+                .showInBestPositionFor(dataContext)
+        }
+    }
+}
+
+private val LOG = Logger.getInstance(WalkthroughExportAction::class.java)

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughHistoryAction.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughHistoryAction.kt
@@ -2,6 +2,7 @@ package com.forketyfork.walkthrough
 
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.actionSystem.DefaultActionGroup
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.popup.JBPopupFactory
@@ -16,49 +17,71 @@ class WalkthroughHistoryAction : AnAction() {
 
     override fun actionPerformed(event: AnActionEvent) {
         val project = event.project ?: return
-        val records = WalkthroughHistoryService.getInstance(project).list()
-        if (records.isEmpty()) {
-            JBPopupFactory.getInstance()
-                .createMessage("No walkthrough history for this project")
-                .showInBestPositionFor(event.dataContext)
-            return
+        showWalkthroughHistoryPopup(project, event.dataContext, "Walkthrough History") { record ->
+            replayWalkthrough(project, record, event.dataContext)
         }
-
-        val actionGroup = DefaultActionGroup().apply {
-            records.forEach { record ->
-                add(ReplayWalkthroughAction(project, record))
-            }
-        }
-        JBPopupFactory.getInstance()
-            .createActionGroupPopup(
-                "Walkthrough History",
-                actionGroup,
-                event.dataContext,
-                JBPopupFactory.ActionSelectionAid.SPEEDSEARCH,
-                true,
-            )
-            .showInBestPositionFor(event.dataContext)
     }
 }
 
-private class ReplayWalkthroughAction(private val project: Project, private val record: WalkthroughRecord) :
-    AnAction(formatRecord(record)) {
-    override fun actionPerformed(event: AnActionEvent) {
-        val shown = when (record.targetKind) {
-            WalkthroughTargetKind.File -> showWalkthroughItems(project, record.items)
+private fun replayWalkthrough(project: Project, record: WalkthroughRecord, dataContext: DataContext) {
+    val shown = when (record.targetKind) {
+        WalkthroughTargetKind.File -> showWalkthroughItems(project, record.items)
 
-            WalkthroughTargetKind.Diff -> showDiffWalkthroughSession(
-                project = project,
-                descriptors = record.diffDescriptors,
-                items = record.items,
-                acceptsQuestions = false,
-            ) != null
+        WalkthroughTargetKind.Diff -> showDiffWalkthroughSession(
+            project = project,
+            descriptors = record.diffDescriptors,
+            items = record.items,
+            acceptsQuestions = false,
+        ) != null
+    }
+    if (!shown) {
+        JBPopupFactory.getInstance()
+            .createMessage("No active editor for walkthrough replay")
+            .showInBestPositionFor(dataContext)
+    }
+}
+
+/**
+ * Shows the saved walkthroughs for [project] in a searchable list popup. Selecting an entry invokes
+ * [onSelect] with the chosen record. Shared by the replay and Markdown-export actions so both expose
+ * the same history list.
+ */
+internal fun showWalkthroughHistoryPopup(
+    project: Project,
+    dataContext: DataContext,
+    title: String,
+    onSelect: (WalkthroughRecord) -> Unit,
+) {
+    val records = WalkthroughHistoryService.getInstance(project).list()
+    if (records.isEmpty()) {
+        JBPopupFactory.getInstance()
+            .createMessage("No walkthrough history for this project")
+            .showInBestPositionFor(dataContext)
+        return
+    }
+
+    val actionGroup = DefaultActionGroup().apply {
+        records.forEach { record ->
+            add(SelectWalkthroughAction(record, onSelect))
         }
-        if (!shown) {
-            JBPopupFactory.getInstance()
-                .createMessage("No active editor for walkthrough replay")
-                .showInBestPositionFor(event.dataContext)
-        }
+    }
+    JBPopupFactory.getInstance()
+        .createActionGroupPopup(
+            title,
+            actionGroup,
+            dataContext,
+            JBPopupFactory.ActionSelectionAid.SPEEDSEARCH,
+            true,
+        )
+        .showInBestPositionFor(dataContext)
+}
+
+private class SelectWalkthroughAction(
+    private val record: WalkthroughRecord,
+    private val onSelect: (WalkthroughRecord) -> Unit,
+) : AnAction(formatRecord(record)) {
+    override fun actionPerformed(event: AnActionEvent) {
+        onSelect(record)
     }
 }
 

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughMarkdownExporter.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughMarkdownExporter.kt
@@ -1,0 +1,74 @@
+package com.forketyfork.walkthrough
+
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+
+private const val TOP_LEVEL_HEADING_LEVEL = 2
+private const val MAX_HEADING_LEVEL = 6
+
+private val exportTimestampFormatter = DateTimeFormatter
+    .ofLocalizedDateTime(FormatStyle.MEDIUM)
+    .withZone(ZoneId.systemDefault())
+
+/**
+ * Renders a saved [WalkthroughRecord] as a standalone Markdown document so a walkthrough can be
+ * shared outside the IDE — pasted into a pull request, an onboarding doc, or a wiki. Each item
+ * becomes a section headed by its step label; inserted tangent answers nest under their parent
+ * step via deeper heading levels. The item bodies are already Markdown and are emitted verbatim.
+ */
+internal fun renderWalkthroughMarkdown(record: WalkthroughRecord): String {
+    val builder = StringBuilder()
+    builder.append("# ").append(record.description.trim()).append("\n\n")
+    builder.append("_Exported from Walkthrough · ")
+        .append(exportTimestampFormatter.format(record.createdAtInstantOrEpoch()))
+        .append("_\n")
+
+    record.items.forEachIndexed { index, item ->
+        val label = item.label?.takeIf { it.isNotBlank() } ?: (index + 1).toString()
+        builder.append('\n')
+        builder.append("#".repeat(headingLevelForLabel(label)))
+            .append(" Step ")
+            .append(label)
+            .append("\n\n")
+        itemLocation(item, record.targetKind)?.let { location ->
+            builder.append(location).append("\n\n")
+        }
+        builder.append(item.text.trim()).append('\n')
+    }
+
+    return builder.toString()
+}
+
+private fun headingLevelForLabel(label: String): Int {
+    val depth = label.count { character -> character == '.' }
+    return (TOP_LEVEL_HEADING_LEVEL + depth).coerceAtMost(MAX_HEADING_LEVEL)
+}
+
+private fun itemLocation(item: WalkthroughItem, targetKind: WalkthroughTargetKind): String? = when (targetKind) {
+    WalkthroughTargetKind.File -> fileLocation(item)
+    WalkthroughTargetKind.Diff -> diffLocation(item)
+}
+
+private fun fileLocation(item: WalkthroughItem): String? {
+    val file = item.file?.takeIf { it.isNotBlank() }
+    val line = item.line
+    return when {
+        file != null && line != null -> "`$file:$line`"
+        file != null -> "`$file`"
+        line != null -> "Line $line"
+        else -> null
+    }
+}
+
+private fun diffLocation(item: WalkthroughItem): String? {
+    val file = item.diffFile?.takeIf { it.isNotBlank() } ?: item.file?.takeIf { it.isNotBlank() }
+    val details = buildList {
+        add("diff")
+        item.diffSide?.let { side ->
+            add(if (side == DiffSide.Left) "left side" else "right side")
+        }
+        item.line?.let { line -> add("line $line") }
+    }.joinToString(", ")
+    return if (file != null) "`$file` ($details)" else "($details)"
+}

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughMarkdownExporter.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughMarkdownExporter.kt
@@ -34,7 +34,13 @@ internal fun renderWalkthroughMarkdown(record: WalkthroughRecord): String {
         itemLocation(item, record.targetKind)?.let { location ->
             builder.append(location).append("\n\n")
         }
-        builder.append(item.text.trim()).append('\n')
+        // Emit the Markdown body verbatim — trimming it would strip significant leading whitespace
+        // such as an indented code block. Only normalize the trailing delimiter newline the
+        // exporter itself adds between sections.
+        builder.append(item.text)
+        if (!item.text.endsWith("\n")) {
+            builder.append('\n')
+        }
     }
 
     return builder.toString()

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -52,6 +52,11 @@
                 class="com.forketyfork.walkthrough.WalkthroughHistoryAction"
                 text="Show Walkthrough History"
                 description="Show previous walkthroughs for the current project"/>
+            <action
+                id="com.forketyfork.walkthrough.ExportMarkdown"
+                class="com.forketyfork.walkthrough.WalkthroughExportAction"
+                text="Export Walkthrough to Markdown…"
+                description="Export a saved walkthrough as a shareable Markdown document"/>
         </group>
     </actions>
 </idea-plugin>

--- a/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughMarkdownExporterTest.kt
+++ b/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughMarkdownExporterTest.kt
@@ -54,6 +54,7 @@ class WalkthroughMarkdownExporterTest {
             ## Step 2
 
             Finally the session is created.
+
             """.trimIndent(),
             body,
         )

--- a/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughMarkdownExporterTest.kt
+++ b/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughMarkdownExporterTest.kt
@@ -92,6 +92,27 @@ class WalkthroughMarkdownExporterTest {
     }
 
     @Test
+    fun preservesSignificantLeadingAndTrailingBodyWhitespace() {
+        val record = WalkthroughRecord(
+            id = "20260509-043400-000-code-block-abc12345",
+            createdAt = "2026-05-09T04:34:00Z",
+            description = "Indented code block",
+            items = listOf(
+                WalkthroughItem(
+                    text = "    val x = 1\n    val y = 2\n",
+                    label = "1",
+                ),
+            ),
+        )
+
+        val markdown = renderWalkthroughMarkdown(record)
+
+        // The indented code block (leading spaces) must survive, and the trailing newline must
+        // not be doubled even though the body already ends with one.
+        assertTrue(markdown.endsWith("## Step 1\n\n    val x = 1\n    val y = 2\n"))
+    }
+
+    @Test
     fun fallsBackToSequentialNumbersWhenLabelsAreMissing() {
         val record = WalkthroughRecord(
             id = "20260509-043400-000-unlabeled-abc12345",

--- a/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughMarkdownExporterTest.kt
+++ b/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughMarkdownExporterTest.kt
@@ -1,0 +1,113 @@
+package com.forketyfork.walkthrough
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class WalkthroughMarkdownExporterTest {
+    @Test
+    fun rendersTitleNestedStepsAndFileLocations() {
+        val record = WalkthroughRecord(
+            id = "20260509-043400-000-auth-tour-abc12345",
+            createdAt = "2026-05-09T04:34:00Z",
+            description = "How authentication works",
+            items = listOf(
+                WalkthroughItem(
+                    text = "Requests enter through the filter.",
+                    file = "src/Auth.kt",
+                    line = 12,
+                    label = "1",
+                ),
+                WalkthroughItem(
+                    text = "The token is validated here.",
+                    file = "src/Token.kt",
+                    label = "1.1",
+                    parentLabel = "1",
+                ),
+                WalkthroughItem(
+                    text = "Finally the session is created.",
+                    label = "2",
+                ),
+            ),
+        )
+
+        val markdown = renderWalkthroughMarkdown(record)
+        val body = markdown.substringAfter("_\n")
+
+        assertTrue(markdown.startsWith("# How authentication works\n\n"))
+        assertEquals(
+            """
+
+            ## Step 1
+
+            `src/Auth.kt:12`
+
+            Requests enter through the filter.
+
+            ### Step 1.1
+
+            `src/Token.kt`
+
+            The token is validated here.
+
+            ## Step 2
+
+            Finally the session is created.
+            """.trimIndent(),
+            body,
+        )
+    }
+
+    @Test
+    fun rendersDiffLocationsWithSideAndLine() {
+        val record = WalkthroughRecord(
+            id = "20260509-043400-000-pr-review-abc12345",
+            createdAt = "2026-05-09T04:34:00Z",
+            description = "Review the change",
+            targetKind = WalkthroughTargetKind.Diff,
+            diffDescriptors = listOf(
+                DiffWalkthroughDescriptor(
+                    id = "change",
+                    file = "src/Foo.kt",
+                    leftCommit = "1111111111111111111111111111111111111111",
+                    rightCommit = "2222222222222222222222222222222222222222",
+                ),
+            ),
+            items = listOf(
+                WalkthroughItem(
+                    text = "This line moved.",
+                    line = 20,
+                    diffId = "change",
+                    diffFile = "src/Foo.kt",
+                    diffSide = DiffSide.Right,
+                    label = "1",
+                ),
+            ),
+        )
+
+        val markdown = renderWalkthroughMarkdown(record)
+
+        assertTrue(markdown.contains("## Step 1\n\n`src/Foo.kt` (diff, right side, line 20)\n\nThis line moved.\n"))
+    }
+
+    @Test
+    fun fallsBackToSequentialNumbersWhenLabelsAreMissing() {
+        val record = WalkthroughRecord(
+            id = "20260509-043400-000-unlabeled-abc12345",
+            createdAt = "2026-05-09T04:34:00Z",
+            description = "Unlabeled tour",
+            items = listOf(
+                WalkthroughItem(text = "First step."),
+                WalkthroughItem(text = "Second step."),
+            ),
+        )
+
+        val markdown = renderWalkthroughMarkdown(record)
+
+        assertTrue(markdown.contains("## Step 1\n\nFirst step.\n"))
+        assertTrue(markdown.contains("## Step 2\n\nSecond step.\n"))
+        // No location line should be emitted when the item has no file or line.
+        assertFalse(markdown.contains("``"))
+    }
+}


### PR DESCRIPTION
Add a Tools -> Walkthrough -> Export Walkthrough to Markdown action that
turns any saved walkthrough into a shareable Markdown document. Each step
(and its inserted follow-up answer steps) becomes a section headed by its
step label and annotated with its source location, so walkthroughs can be
pasted into pull requests, onboarding docs, or wikis.

Extract the history list popup into a shared helper reused by both the
replay and export actions.

https://claude.ai/code/session_01AbuxMY81ANZYUJzLu8tjor
