### PR TITLE
fix: stop popup drag from reordering covered editor tabs (#38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Dragging or resizing a walkthrough popup that overlaps the editor tab bar no longer reorders the
+  tabs underneath (#38).
+
 ## [0.4.1]
 
 ### Added

--- a/src/main/kotlin/com/forketyfork/walkthrough/DiffWalkthroughSession.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/DiffWalkthroughSession.kt
@@ -69,7 +69,6 @@ fun showDiffWalkthroughSession(
     }
 
     var popupRef: WalkthroughPopupSurface? = null
-    var currentEditor: Editor? = null
     lateinit var controller: DiffWalkthroughController
 
     fun updatePopupPalette(palette: WalkthroughPalette) {
@@ -87,7 +86,6 @@ fun showDiffWalkthroughSession(
         descriptors = descriptors,
         sessionDisposable = sessionDisposable,
         popupProvider = { popupRef },
-        currentEditorUpdater = { editor -> currentEditor = editor },
     )
 
     val panel = createWalkthroughPanel(
@@ -99,13 +97,6 @@ fun showDiffWalkthroughSession(
         onClose = { popupRef?.cancel() },
     )
     makeComponentHierarchyTransparent(panel)
-
-    installPopupInteractionHandler(
-        panel = panel,
-        popupProvider = { popupRef },
-        editorProvider = { currentEditor },
-        onInteractionEnd = { saveCurrentGeometry(popupRef) },
-    )
 
     ApplicationManager.getApplication().messageBus.connect(sessionDisposable).subscribe(
         WalkthroughSettingsListener.TOPIC,
@@ -124,6 +115,7 @@ fun showDiffWalkthroughSession(
             registry.remove(session.id)
             Disposer.dispose(sessionDisposable)
         },
+        onInteractionEnd = { saveCurrentGeometry(popupRef) },
     )
     popupRef = popup
     Disposer.register(sessionDisposable, popup)
@@ -139,13 +131,11 @@ class WalkthroughDiffExtension : DiffExtension() {
     }
 }
 
-@Suppress("LongParameterList")
 private class DiffWalkthroughController(
     private val project: Project,
     private val descriptors: List<DiffWalkthroughDescriptor>,
     private val sessionDisposable: CheckedDisposable,
     private val popupProvider: () -> WalkthroughPopupSurface?,
-    private val currentEditorUpdater: (Editor) -> Unit,
 ) {
     private var pendingNavigationId = 0
     private var activeViewer: FrameDiffTool.DiffViewer? = null
@@ -217,7 +207,6 @@ private class DiffWalkthroughController(
         } else {
             item.copy(line = null)
         }
-        currentEditorUpdater(editor)
         popup.update(editor, popupItem)
         popup.connectorHidden = false
         applyPopupGeometryForItem(popup, editor, popupItem)

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughOrchestrator.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughOrchestrator.kt
@@ -105,13 +105,6 @@ fun showWalkthroughSession(
     )
     makeComponentHierarchyTransparent(panel)
 
-    installPopupInteractionHandler(
-        panel = panel,
-        popupProvider = { popupRef },
-        editorProvider = { currentEditor },
-        onInteractionEnd = { saveCurrentGeometry(popupRef) },
-    )
-
     project.messageBus.connect(sessionDisposable).subscribe(
         FileEditorManagerListener.FILE_EDITOR_MANAGER,
         object : FileEditorManagerListener {
@@ -138,6 +131,7 @@ fun showWalkthroughSession(
             registry.remove(session.id)
             Disposer.dispose(sessionDisposable)
         },
+        onInteractionEnd = { saveCurrentGeometry(popupRef) },
     )
     popupRef = popup
     Disposer.register(sessionDisposable, popup)

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupInteraction.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupInteraction.kt
@@ -1,13 +1,14 @@
 package com.forketyfork.walkthrough
 
+import com.intellij.openapi.Disposable
 import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.wm.IdeGlassPane
+import com.intellij.openapi.wm.IdeGlassPaneUtil
+import com.intellij.ui.awt.RelativePoint
 import java.awt.Component
-import java.awt.Container
 import java.awt.Cursor
 import java.awt.Dimension
 import java.awt.Point
-import java.awt.event.ContainerAdapter
-import java.awt.event.ContainerEvent
 import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
 import javax.swing.JComponent
@@ -19,9 +20,6 @@ import java.awt.Color as AwtColor
 private const val DRAG_HANDLE_HEIGHT_PX = 64
 private const val CLOSE_BUTTON_HIT_BOX_PX = 60
 private const val RESIZE_HANDLE_SIZE_PX = 26
-private const val INTERACTION_LISTENER_CLIENT_PROPERTY = "walkthrough.popup.interaction.listener"
-private const val INTERACTION_CONTAINER_LISTENER_CLIENT_PROPERTY =
-    "walkthrough.popup.interaction.container.listener"
 
 private enum class PopupInteractionMode {
     Drag,
@@ -41,112 +39,131 @@ internal fun makeComponentHierarchyTransparent(component: Component?) {
     }
 }
 
+/**
+ * Routes popup drag and resize gestures through an [IdeGlassPane] mouse preprocessor. The editor
+ * file tabs install their own [com.intellij.ui.MouseDragHelper] preprocessor (weight `2`) on the
+ * same glass pane; registering with the default weight `0` makes this listener run first, so
+ * consuming a gesture that starts on the popup prevents the covered tabs from reordering.
+ */
 internal fun installPopupInteractionHandler(
-    panel: JComponent,
+    editor: Editor,
+    parentDisposable: Disposable,
     popupProvider: () -> WalkthroughPopupSurface?,
     editorProvider: () -> Editor?,
     onInteractionEnd: () -> Unit,
-) {
-    var lastScreenPoint: Point? = null
-    var interactionMode: PopupInteractionMode? = null
-
-    val interactionListener = object : MouseAdapter() {
-        override fun mousePressed(event: MouseEvent) {
-            if (event.button != MouseEvent.BUTTON1) {
-                interactionMode = null
-                lastScreenPoint = null
-                return
-            }
-            interactionMode = when {
-                isWithinResizeHandle(panel, event.component, event.point) -> PopupInteractionMode.Resize
-                isWithinDragHandle(panel, event.component, event.point) -> PopupInteractionMode.Drag
-                else -> null
-            }
-            lastScreenPoint = interactionMode?.let { event.locationOnScreen }
-        }
-
-        override fun mouseDragged(event: MouseEvent) {
-            val mode = interactionMode
-            val popup = popupProvider()
-            val editor = editorProvider()
-            if (mode != null && popup != null && editor != null) {
-                val previousScreenPoint = lastScreenPoint ?: event.locationOnScreen
-                val currentScreenPoint = event.locationOnScreen
-                handlePopupDrag(panel, mode, popup, editor, previousScreenPoint, currentScreenPoint)
-                lastScreenPoint = currentScreenPoint
-            }
-        }
-
-        override fun mouseMoved(event: MouseEvent) {
-            updateInteractionCursor(panel, event.component, event.point)
-        }
-
-        override fun mouseReleased(event: MouseEvent) {
-            val hadInteraction = interactionMode != null
-            interactionMode = null
-            lastScreenPoint = null
-            updateInteractionCursor(panel, event.component, event.point)
-            if (hadInteraction) {
-                onInteractionEnd()
-            }
-        }
-
-        override fun mouseExited(event: MouseEvent) {
-            if (interactionMode == null) {
-                event.component.cursor = Cursor.getDefaultCursor()
-                panel.cursor = Cursor.getDefaultCursor()
-            }
-        }
-    }
-
-    attachMouseListenersRecursively(panel, interactionListener)
+): Boolean {
+    val glassPane = findGlassPane(editor) ?: return false
+    val listener = WalkthroughPopupInteractionListener(
+        glassPane = glassPane,
+        popupProvider = popupProvider,
+        editorProvider = editorProvider,
+        onInteractionEnd = onInteractionEnd,
+    )
+    glassPane.addMousePreprocessor(listener, parentDisposable)
+    glassPane.addMouseMotionPreprocessor(listener, parentDisposable)
+    return true
 }
 
-private fun attachMouseListenersRecursively(component: Component, listener: MouseAdapter) {
-    if (component is JComponent) {
-        if (component.getClientProperty(
-                INTERACTION_LISTENER_CLIENT_PROPERTY,
-            ) !== listener
-        ) {
-            component.addMouseListener(listener)
-            component.addMouseMotionListener(listener)
-            component.putClientProperty(INTERACTION_LISTENER_CLIENT_PROPERTY, listener)
-        }
-    } else {
-        component.addMouseListener(listener)
-        component.addMouseMotionListener(listener)
+private fun findGlassPane(editor: Editor): IdeGlassPane? {
+    val component = editor.contentComponent
+    if (!component.isShowing) {
+        return null
     }
-    if (component is Container) {
-        component.components.forEach { child ->
-            attachMouseListenersRecursively(child, listener)
+    return runCatching { IdeGlassPaneUtil.find(component) }.getOrNull()
+}
+
+private class WalkthroughPopupInteractionListener(
+    private val glassPane: IdeGlassPane,
+    private val popupProvider: () -> WalkthroughPopupSurface?,
+    private val editorProvider: () -> Editor?,
+    private val onInteractionEnd: () -> Unit,
+) : MouseAdapter() {
+    private var interactionMode: PopupInteractionMode? = null
+    private var lastScreenPoint: Point? = null
+
+    override fun mousePressed(event: MouseEvent) {
+        val mode = popupProvider()
+            ?.takeIf { event.button == MouseEvent.BUTTON1 }
+            ?.let { handleRegionAt(it, event) }
+        if (mode == null) {
+            reset()
+            return
         }
-        if (component is JComponent &&
-            component.getClientProperty(INTERACTION_CONTAINER_LISTENER_CLIENT_PROPERTY) == null
-        ) {
-            val containerListener = object : ContainerAdapter() {
-                override fun componentAdded(event: ContainerEvent) {
-                    attachMouseListenersRecursively(event.child, listener)
-                }
-            }
-            component.addContainerListener(containerListener)
-            component.putClientProperty(INTERACTION_CONTAINER_LISTENER_CLIENT_PROPERTY, containerListener)
+        interactionMode = mode
+        lastScreenPoint = RelativePoint(event).screenPoint
+        event.consume()
+    }
+
+    override fun mouseDragged(event: MouseEvent) {
+        val mode = interactionMode ?: return
+        val popup = popupProvider()
+        val editor = editorProvider()
+        if (popup == null || editor == null) {
+            return
         }
+        val currentScreenPoint = RelativePoint(event).screenPoint
+        val previousScreenPoint = lastScreenPoint ?: currentScreenPoint
+        handlePopupDrag(popup.content, mode, popup, editor, previousScreenPoint, currentScreenPoint)
+        lastScreenPoint = currentScreenPoint
+        event.consume()
+    }
+
+    override fun mouseReleased(event: MouseEvent) {
+        if (interactionMode == null) {
+            return
+        }
+        reset()
+        event.consume()
+        onInteractionEnd()
+    }
+
+    override fun mouseMoved(event: MouseEvent) {
+        val popup = popupProvider()
+        glassPane.setCursor(popup?.let { resolveCursor(it, event) }, this)
+    }
+
+    private fun resolveCursor(popup: WalkthroughPopupSurface, event: MouseEvent): Cursor? =
+        when (handleRegionAt(popup, event)) {
+            PopupInteractionMode.Resize -> Cursor.getPredefinedCursor(Cursor.SE_RESIZE_CURSOR)
+            PopupInteractionMode.Drag -> Cursor.getPredefinedCursor(Cursor.MOVE_CURSOR)
+            null -> if (isWithinPopup(popup, event)) Cursor.getDefaultCursor() else null
+        }
+
+    private fun reset() {
+        interactionMode = null
+        lastScreenPoint = null
     }
 }
 
-private fun updateInteractionCursor(panel: JComponent, component: Component, point: Point) {
-    val cursor = when {
-        isWithinResizeHandle(panel, component, point) ->
-            Cursor.getPredefinedCursor(Cursor.SE_RESIZE_CURSOR)
-
-        isWithinDragHandle(panel, component, point) ->
-            Cursor.getPredefinedCursor(Cursor.MOVE_CURSOR)
-
-        else -> Cursor.getDefaultCursor()
-    }
-    component.cursor = cursor
-    panel.cursor = cursor
+private fun pointInContent(popup: WalkthroughPopupSurface, event: MouseEvent): Point? {
+    val contentLocation = popup.popupLocationOnScreen() ?: return null
+    val screenPoint = RelativePoint(event).screenPoint
+    return Point(screenPoint.x - contentLocation.x, screenPoint.y - contentLocation.y)
 }
+
+private fun isWithinPopup(popup: WalkthroughPopupSurface, event: MouseEvent): Boolean {
+    val point = pointInContent(popup, event) ?: return false
+    val content = popup.content
+    return point.x in 0..content.width && point.y in 0..content.height
+}
+
+private fun handleRegionAt(popup: WalkthroughPopupSurface, event: MouseEvent): PopupInteractionMode? {
+    val point = pointInContent(popup, event) ?: return null
+    val content = popup.content
+    val withinBounds = point.x in 0..content.width && point.y in 0..content.height
+    return when {
+        !withinBounds -> null
+        resizeHandleContains(content.width, content.height, point) -> PopupInteractionMode.Resize
+        dragHandleContains(content.width, point) -> PopupInteractionMode.Drag
+        else -> null
+    }
+}
+
+internal fun dragHandleContains(width: Int, point: Point): Boolean =
+    point.y in 0..DRAG_HANDLE_HEIGHT_PX && point.x in 0..(width - CLOSE_BUTTON_HIT_BOX_PX)
+
+internal fun resizeHandleContains(width: Int, height: Int, point: Point): Boolean =
+    point.x in (width - RESIZE_HANDLE_SIZE_PX)..width && point.y in (height - RESIZE_HANDLE_SIZE_PX)..height
 
 @Suppress("LongParameterList")
 private fun handlePopupDrag(
@@ -173,18 +190,6 @@ private fun handlePopupDrag(
             deltaY = (currentScreenPoint.y - previousScreenPoint.y).toFloat(),
         )
     }
-}
-
-private fun isWithinDragHandle(panel: JComponent, component: Component, point: Point): Boolean {
-    val pointInPanel = SwingUtilities.convertPoint(component, point, panel)
-    return pointInPanel.y <= DRAG_HANDLE_HEIGHT_PX &&
-        pointInPanel.x <= panel.width - CLOSE_BUTTON_HIT_BOX_PX
-}
-
-private fun isWithinResizeHandle(panel: JComponent, component: Component, point: Point): Boolean {
-    val pointInPanel = SwingUtilities.convertPoint(component, point, panel)
-    return pointInPanel.x >= panel.width - RESIZE_HANDLE_SIZE_PX &&
-        pointInPanel.y >= panel.height - RESIZE_HANDLE_SIZE_PX
 }
 
 private fun resizePopupBy(

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupInteraction.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupInteraction.kt
@@ -46,13 +46,12 @@ internal fun makeComponentHierarchyTransparent(component: Component?) {
  * consuming a gesture that starts on the popup prevents the covered tabs from reordering.
  */
 internal fun installPopupInteractionHandler(
-    editor: Editor,
+    glassPane: IdeGlassPane,
     parentDisposable: Disposable,
     popupProvider: () -> WalkthroughPopupSurface?,
     editorProvider: () -> Editor?,
     onInteractionEnd: () -> Unit,
-): Boolean {
-    val glassPane = findGlassPane(editor) ?: return false
+) {
     val listener = WalkthroughPopupInteractionListener(
         glassPane = glassPane,
         popupProvider = popupProvider,
@@ -61,10 +60,9 @@ internal fun installPopupInteractionHandler(
     )
     glassPane.addMousePreprocessor(listener, parentDisposable)
     glassPane.addMouseMotionPreprocessor(listener, parentDisposable)
-    return true
 }
 
-private fun findGlassPane(editor: Editor): IdeGlassPane? {
+internal fun findGlassPane(editor: Editor): IdeGlassPane? {
     val component = editor.contentComponent
     if (!component.isShowing) {
         return null
@@ -118,15 +116,14 @@ private class WalkthroughPopupInteractionListener(
     }
 
     override fun mouseMoved(event: MouseEvent) {
-        val popup = popupProvider()
-        glassPane.setCursor(popup?.let { resolveCursor(it, event) }, this)
+        glassPane.setCursor(popupProvider()?.let { resolveHandleCursor(it, event) }, this)
     }
 
-    private fun resolveCursor(popup: WalkthroughPopupSurface, event: MouseEvent): Cursor? =
+    private fun resolveHandleCursor(popup: WalkthroughPopupSurface, event: MouseEvent): Cursor? =
         when (handleRegionAt(popup, event)) {
             PopupInteractionMode.Resize -> Cursor.getPredefinedCursor(Cursor.SE_RESIZE_CURSOR)
             PopupInteractionMode.Drag -> Cursor.getPredefinedCursor(Cursor.MOVE_CURSOR)
-            null -> if (isWithinPopup(popup, event)) Cursor.getDefaultCursor() else null
+            null -> null
         }
 
     private fun reset() {
@@ -141,16 +138,10 @@ private fun pointInContent(popup: WalkthroughPopupSurface, event: MouseEvent): P
     return Point(screenPoint.x - contentLocation.x, screenPoint.y - contentLocation.y)
 }
 
-private fun isWithinPopup(popup: WalkthroughPopupSurface, event: MouseEvent): Boolean {
-    val point = pointInContent(popup, event) ?: return false
-    val content = popup.content
-    return point.x in 0..content.width && point.y in 0..content.height
-}
-
 private fun handleRegionAt(popup: WalkthroughPopupSurface, event: MouseEvent): PopupInteractionMode? {
     val point = pointInContent(popup, event) ?: return null
     val content = popup.content
-    val withinBounds = point.x in 0..content.width && point.y in 0..content.height
+    val withinBounds = point.x in 0 until content.width && point.y in 0 until content.height
     return when {
         !withinBounds -> null
         resizeHandleContains(content.width, content.height, point) -> PopupInteractionMode.Resize
@@ -163,7 +154,7 @@ internal fun dragHandleContains(width: Int, point: Point): Boolean =
     point.y in 0..DRAG_HANDLE_HEIGHT_PX && point.x in 0..(width - CLOSE_BUTTON_HIT_BOX_PX)
 
 internal fun resizeHandleContains(width: Int, height: Int, point: Point): Boolean =
-    point.x in (width - RESIZE_HANDLE_SIZE_PX)..width && point.y in (height - RESIZE_HANDLE_SIZE_PX)..height
+    point.x in (width - RESIZE_HANDLE_SIZE_PX) until width && point.y in (height - RESIZE_HANDLE_SIZE_PX) until height
 
 @Suppress("LongParameterList")
 private fun handlePopupDrag(

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupSurface.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupSurface.kt
@@ -4,6 +4,8 @@ import com.intellij.openapi.Disposable
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.event.VisibleAreaEvent
 import com.intellij.openapi.editor.event.VisibleAreaListener
+import com.intellij.openapi.util.Disposer
+import com.intellij.openapi.wm.IdeGlassPane
 import java.awt.BasicStroke
 import java.awt.Dimension
 import java.awt.Graphics
@@ -59,7 +61,8 @@ internal class WalkthroughPopupSurface(
     private var editor: Editor? = null
     private var item: WalkthroughItem? = null
     private var layeredPane: JLayeredPane? = null
-    private var interactionHandlerInstalled = false
+    private var interactionGlassPane: IdeGlassPane? = null
+    private var interactionHandlerDisposable: Disposable? = null
     var connectorHidden: Boolean = false
         set(value) {
             field = value
@@ -104,22 +107,32 @@ internal class WalkthroughPopupSurface(
                 pane.add(this)
             }
         }
-        installInteractionHandlerIfNeeded(editor)
+        refreshInteractionHandler(editor)
         refreshBounds()
         repaint()
     }
 
-    private fun installInteractionHandlerIfNeeded(editor: Editor) {
-        if (interactionHandlerInstalled) {
+    private fun refreshInteractionHandler(editor: Editor) {
+        val targetGlassPane = findGlassPane(editor)
+        if (targetGlassPane === interactionGlassPane) {
             return
         }
-        interactionHandlerInstalled = installPopupInteractionHandler(
-            editor = editor,
-            parentDisposable = this,
+        interactionHandlerDisposable?.let(Disposer::dispose)
+        interactionHandlerDisposable = null
+        interactionGlassPane = targetGlassPane
+        if (targetGlassPane == null) {
+            return
+        }
+        val handlerDisposable = Disposer.newDisposable("WalkthroughPopupInteraction")
+        Disposer.register(this, handlerDisposable)
+        installPopupInteractionHandler(
+            glassPane = targetGlassPane,
+            parentDisposable = handlerDisposable,
             popupProvider = { this },
             editorProvider = { this.editor },
             onInteractionEnd = onInteractionEnd,
         )
+        interactionHandlerDisposable = handlerDisposable
     }
 
     fun updatePalette(palette: WalkthroughPalette) {

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupSurface.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupSurface.kt
@@ -52,12 +52,14 @@ internal class WalkthroughPopupSurface(
     val content: JComponent,
     private var palette: WalkthroughPalette,
     private val onCloseRequested: () -> Unit,
+    private val onInteractionEnd: () -> Unit = {},
 ) : JComponent(),
     VisibleAreaListener,
     Disposable {
     private var editor: Editor? = null
     private var item: WalkthroughItem? = null
     private var layeredPane: JLayeredPane? = null
+    private var interactionHandlerInstalled = false
     var connectorHidden: Boolean = false
         set(value) {
             field = value
@@ -102,8 +104,22 @@ internal class WalkthroughPopupSurface(
                 pane.add(this)
             }
         }
+        installInteractionHandlerIfNeeded(editor)
         refreshBounds()
         repaint()
+    }
+
+    private fun installInteractionHandlerIfNeeded(editor: Editor) {
+        if (interactionHandlerInstalled) {
+            return
+        }
+        interactionHandlerInstalled = installPopupInteractionHandler(
+            editor = editor,
+            parentDisposable = this,
+            popupProvider = { this },
+            editorProvider = { this.editor },
+            onInteractionEnd = onInteractionEnd,
+        )
     }
 
     fun updatePalette(palette: WalkthroughPalette) {

--- a/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughPopupInteractionTest.kt
+++ b/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughPopupInteractionTest.kt
@@ -1,0 +1,57 @@
+package com.forketyfork.walkthrough
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.awt.Point
+
+class WalkthroughPopupInteractionTest {
+
+    private val width = 400
+    private val height = 300
+
+    @Test
+    fun dragHandleContainsPointInTopBand() {
+        assertTrue(dragHandleContains(width, Point(20, 20)))
+    }
+
+    @Test
+    fun dragHandleContainsPointOnLowerBoundary() {
+        assertTrue(dragHandleContains(width, Point(0, 64)))
+    }
+
+    @Test
+    fun dragHandleExcludesPointBelowHandle() {
+        assertFalse(dragHandleContains(width, Point(20, 120)))
+    }
+
+    @Test
+    fun dragHandleExcludesCloseButtonHitBox() {
+        assertFalse(dragHandleContains(width, Point(width - 30, 20)))
+    }
+
+    @Test
+    fun dragHandleExcludesNegativePoint() {
+        assertFalse(dragHandleContains(width, Point(-5, 20)))
+    }
+
+    @Test
+    fun resizeHandleContainsBottomRightCorner() {
+        assertTrue(resizeHandleContains(width, height, Point(width - 5, height - 5)))
+    }
+
+    @Test
+    fun resizeHandleContainsCornerBoundary() {
+        assertTrue(resizeHandleContains(width, height, Point(width - 26, height - 26)))
+    }
+
+    @Test
+    fun resizeHandleExcludesCenter() {
+        assertFalse(resizeHandleContains(width, height, Point(width / 2, height / 2)))
+    }
+
+    @Test
+    fun resizeHandleExcludesPointBeyondWidth() {
+        assertFalse(resizeHandleContains(width, height, Point(width + 10, height - 5)))
+    }
+}

--- a/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughPopupInteractionTest.kt
+++ b/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughPopupInteractionTest.kt
@@ -54,4 +54,14 @@ class WalkthroughPopupInteractionTest {
     fun resizeHandleExcludesPointBeyondWidth() {
         assertFalse(resizeHandleContains(width, height, Point(width + 10, height - 5)))
     }
+
+    @Test
+    fun resizeHandleExcludesRightEdgeOutsideContent() {
+        assertFalse(resizeHandleContains(width, height, Point(width, height - 5)))
+    }
+
+    @Test
+    fun resizeHandleExcludesBottomEdgeOutsideContent() {
+        assertFalse(resizeHandleContains(width, height, Point(width - 5, height)))
+    }
 }


### PR DESCRIPTION
Closes #38

## Solution

When a walkthrough popup overlapped the editor tab bar, dragging it reordered the tab underneath instead of just moving the popup.

The editor file tabs (`JBTabsImpl`) install their own drag handler as a mouse preprocessor on the IDE glass pane. Glass-pane preprocessors receive mouse events for the whole window, independently of the normal dispatch that delivers events to the popup. So a single drag fired two handlers at once: the popup moved, and the tab handler reordered the tab beneath it.

The popup's drag and resize now run as their own glass-pane preprocessor. It registers with the default `Weighted` weight (`0`), which is lower than the tabs' handler (`2`), so the glass pane invokes it first. When a gesture starts on the popup's drag or resize handle, the preprocessor handles the move/resize itself and consumes the event, so the tab handler never sees it. Consuming is all-or-nothing per event, which is why the popup's drag had to move into the same handler that blocks the tab rather than staying on the panel listeners.

The handler is now installed once from `WalkthroughPopupSurface` when the editor is showing, which covers both the regular and diff walkthrough flows and let the diff session drop the editor-tracking plumbing it only needed for the old wiring.

Known limitation, left for a possible follow-up: a text-selection drag started inside the popup body where the body overlaps a tab can still reach the tab handler, because non-handle drags are intentionally left unconsumed so Compose text selection keeps working. In practice the drag handle covers the tab strip, so this is an edge case.

## Test plan

- [ ] Run a sandbox IDE (`just run`), open a walkthrough, and position the popup so its title/drag handle overlaps the editor tab bar. Drag it and confirm the popup moves while the tabs underneath stay in place.
- [ ] Drag the popup from the bottom-right resize handle while it overlaps the tab bar and confirm the tabs are not reordered.
- [ ] Confirm normal popup interactions still work over the tab bar: close button, navigation buttons, and the follow-up question field.
- [ ] Repeat the drag check in a diff walkthrough to confirm the diff flow behaves the same.
