### PR TITLE
feat: add persistTangents option to keep walkthrough history immutable (#47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- A `persistTangents` option on the walkthrough MCP tools that lets a reusable or presentation
+  walkthrough keep its stored history pristine: follow-up tangent steps are still shown live but
+  no longer written back to the saved walkthrough when disabled (#47).
+
 ### Fixed
 
 - Passing an empty or `null` items payload to the walkthrough MCP tools now returns a clear

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ walkthrough.
   before rendering.
 - Previous and Next navigation inside the popup for multi-step walkthroughs.
 - Users can ask follow-up questions in the popup; answers are inserted as labeled child steps.
+  Reusable or presentation walkthroughs can opt out of persisting these tangent steps to history
+  via the `persistTangents` tool parameter, keeping the stored walkthrough pristine.
 - Per-project walkthrough history stored under `.idea/walkthroughs/`, with a keymap-bindable
   action for replaying previous walkthroughs.
 - User-selectable popup color palettes under the IDE settings.

--- a/src/main/kotlin/com/forketyfork/walkthrough/ShowWalkthroughItemsToolset.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/ShowWalkthroughItemsToolset.kt
@@ -82,6 +82,12 @@ class ShowWalkthroughItemsToolset : McpToolset {
                 "Verify line numbers by reading the actual file before calling this tool — " +
                 "do not estimate from diffs or memory.",
         ) items: String,
+        @McpDescription(
+            "Whether tangent steps inserted later via insert_walkthrough_tangents are persisted " +
+                "into this walkthrough's stored history record. Defaults to true. Set to false for " +
+                "reusable or presentation walkthroughs that should stay pristine across replays: " +
+                "tangents are still inserted and shown live, but the stored history record is left unchanged.",
+        ) persistTangents: Boolean = true,
     ): String {
         val project = requireProject()
         val trimmedDescription = description.trim()
@@ -95,6 +101,7 @@ class ShowWalkthroughItemsToolset : McpToolset {
         val session = withContext(Dispatchers.EDT) {
             showWalkthroughSession(project, labeledItems, acceptsQuestions = true)
         } ?: mcpFail("No active editor")
+        session.persistTangents = persistTangents
 
         val record = WalkthroughHistoryService.getInstance(project)
             .save(trimmedDescription, session.snapshotItems())
@@ -136,6 +143,12 @@ class ShowWalkthroughItemsToolset : McpToolset {
                 "For PRs, pass the merge-base commit as 'leftCommit' and the PR head commit as 'rightCommit'. " +
                 "Verify every line by inspecting that exact file at that exact commit before calling.",
         ) payload: String,
+        @McpDescription(
+            "Whether tangent steps inserted later via insert_walkthrough_tangents are persisted " +
+                "into this walkthrough's stored history record. Defaults to true. Set to false for " +
+                "reusable or presentation walkthroughs that should stay pristine across replays: " +
+                "tangents are still inserted and shown live, but the stored history record is left unchanged.",
+        ) persistTangents: Boolean = true,
     ): String {
         val project = requireProject()
         val trimmedDescription = description.trim()
@@ -152,6 +165,7 @@ class ShowWalkthroughItemsToolset : McpToolset {
                 acceptsQuestions = true,
             )
         } ?: mcpFail("No diff walkthrough items to show")
+        session.persistTangents = persistTangents
 
         val record = WalkthroughHistoryService.getInstance(project).save(
             description = trimmedDescription,
@@ -232,7 +246,9 @@ class ShowWalkthroughItemsToolset : McpToolset {
             "New child labels are derived automatically by appending '.N' to the parent label: " +
             "the first tangent under '3' becomes '3.1', the next '3.2', and so on. The popup " +
             "auto-navigates to the first inserted step. Clears the inline loading spinner so " +
-            "the user can ask another question. After this tool returns, immediately call " +
+            "the user can ask another question. If the walkthrough was shown with " +
+            "persistTangents=false, the inserted steps are shown live but the stored walkthrough " +
+            "history record is left unchanged. After this tool returns, immediately call " +
             "await_walkthrough_question again with the same walkthroughId.",
     )
     suspend fun insertWalkthroughTangents(
@@ -262,8 +278,10 @@ class ShowWalkthroughItemsToolset : McpToolset {
         val inserted = withContext(Dispatchers.EDT) {
             session.insertTangents(trimmedParent, parsedItems)
         }
-        session.historyRecordId?.let { recordId ->
-            WalkthroughHistoryService.getInstance(project).updateItems(recordId, session.snapshotItems())
+        if (session.persistTangents) {
+            session.historyRecordId?.let { recordId ->
+                WalkthroughHistoryService.getInstance(project).updateItems(recordId, session.snapshotItems())
+            }
         }
         val labels = inserted.mapNotNull { it.label }.joinToString(", ")
         return "Inserted ${inserted.size} tangent step(s) under $trimmedParent: $labels"

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughSessionRegistry.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughSessionRegistry.kt
@@ -62,6 +62,9 @@ class WalkthroughSession internal constructor(
     @Volatile
     internal var historyRecordId: String? = null
 
+    @Volatile
+    internal var persistTangents: Boolean = true
+
     private val questionLock = Any()
     private var activeQuestionWaiter: WalkthroughQuestionWaiter? = null
     private var pendingQuestion: WalkthroughTangentQuestion? = null

--- a/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughSessionRegistryTest.kt
+++ b/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughSessionRegistryTest.kt
@@ -370,6 +370,34 @@ class WalkthroughSessionRegistryTest {
     }
 
     @Test
+    fun persistTangentsDefaultsToTrue() {
+        val session = newSession(
+            assignTopLevelLabels(listOf(WalkthroughItem(text = "only"))),
+        )
+        assertTrue(session.persistTangents)
+    }
+
+    @Test
+    fun persistTangentsCanBeDisabledAfterCreation() {
+        val session = newSession(
+            assignTopLevelLabels(listOf(WalkthroughItem(text = "only"))),
+        )
+        session.persistTangents = false
+        assertEquals(false, session.persistTangents)
+    }
+
+    @Test
+    fun createdSessionDefaultsToPersistingTangents() {
+        val registry = WalkthroughSessionRegistry()
+        val session = registry.create(
+            items = assignTopLevelLabels(listOf(WalkthroughItem(text = "only"))),
+            acceptsQuestions = true,
+        )
+
+        assertTrue(session.persistTangents)
+    }
+
+    @Test
     fun removeKeepsDismissedSessionQueryableUntilConsumed() {
         val registry = WalkthroughSessionRegistry()
         val session = registry.create(


### PR DESCRIPTION
Closes #47.

## Solution

Live presentations reuse the same stored walkthrough, but every audience question used to be written back into the history record as tangent steps. Both show tools now take an optional `persistTangents` parameter (default `true`). When an agent passes `false`, tangent steps inserted through `insert_walkthrough_tangents` still appear in the running session, but the saved record under `.idea/walkthroughs/` is left alone.

The flag lives on the live session next to `historyRecordId`, so the initial save is unchanged and only the write-back after tangent insertion is skipped.

## Test plan

- [ ] Start a walkthrough via MCP with `persistTangents=false`, ask a follow-up question, and check that the tangent steps appear in the popup.
- [ ] Confirm the record in `.idea/walkthroughs/` still contains only the original steps.
- [ ] Repeat without the parameter and confirm tangents are persisted as before.
