### PR TITLE
feat: allow show_walkthrough_items to update an existing history record (#49)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `show_walkthrough_items` and `show_diff_walkthrough_items` accept an optional `historyId`
+  parameter to overwrite an existing walkthrough history record in place instead of creating a
+  new one, so iterating on a walkthrough's content no longer clutters the project history (#49).
+
 ### Fixed
 
 - Passing an empty or `null` items payload to the walkthrough MCP tools now returns a clear

--- a/README.md
+++ b/README.md
@@ -115,7 +115,9 @@ walkthrough.
 - Previous and Next navigation inside the popup for multi-step walkthroughs.
 - Users can ask follow-up questions in the popup; answers are inserted as labeled child steps.
 - Per-project walkthrough history stored under `.idea/walkthroughs/`, with a keymap-bindable
-  action for replaying previous walkthroughs.
+  action for replaying previous walkthroughs. Agents can pass a previous walkthrough's
+  `historyId` back into `show_walkthrough_items` or `show_diff_walkthrough_items` to overwrite
+  that record in place instead of creating a new one.
 - User-selectable popup color palettes under the IDE settings.
 - A Compose-based popup UI rendered through Jewel on the IntelliJ Platform.
 

--- a/src/main/kotlin/com/forketyfork/walkthrough/ShowWalkthroughItemsToolset.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/ShowWalkthroughItemsToolset.kt
@@ -82,6 +82,12 @@ class ShowWalkthroughItemsToolset : McpToolset {
                 "Verify line numbers by reading the actual file before calling this tool — " +
                 "do not estimate from diffs or memory.",
         ) items: String,
+        @McpDescription(
+            "Optional history id returned by a previous show_walkthrough_items call. When set, " +
+                "the existing history record with this id is overwritten with the new description " +
+                "and items instead of creating a new history entry — useful when iterating on a " +
+                "walkthrough's content. Leave empty to create a new history record as usual.",
+        ) historyId: String = "",
     ): String {
         val project = requireProject()
         val trimmedDescription = description.trim()
@@ -90,14 +96,25 @@ class ShowWalkthroughItemsToolset : McpToolset {
         val parsedItems = parseFileItems(items)
         if (parsedItems.isEmpty()) mcpFail("items must not be empty")
 
+        val historyService = WalkthroughHistoryService.getInstance(project)
+        val trimmedHistoryId = historyId.trim()
+        if (trimmedHistoryId.isNotBlank()) {
+            historyService.requireOverwritableRecord(trimmedHistoryId, WalkthroughTargetKind.File)
+        }
+
         val labeledItems = assignTopLevelLabels(parsedItems)
 
         val session = withContext(Dispatchers.EDT) {
             showWalkthroughSession(project, labeledItems, acceptsQuestions = true)
         } ?: mcpFail("No active editor")
 
-        val record = WalkthroughHistoryService.getInstance(project)
-            .save(trimmedDescription, session.snapshotItems())
+        val record = historyService.saveOrOverwrite(
+            historyId = trimmedHistoryId,
+            description = trimmedDescription,
+            targetKind = WalkthroughTargetKind.File,
+            diffDescriptors = emptyList(),
+            items = session.snapshotItems(),
+        )
         session.historyRecordId = record?.id
 
         val labels = labeledItems.mapNotNull { it.label }.joinToString(", ")
@@ -136,12 +153,25 @@ class ShowWalkthroughItemsToolset : McpToolset {
                 "For PRs, pass the merge-base commit as 'leftCommit' and the PR head commit as 'rightCommit'. " +
                 "Verify every line by inspecting that exact file at that exact commit before calling.",
         ) payload: String,
+        @McpDescription(
+            "Optional history id returned by a previous show_diff_walkthrough_items call. When set, " +
+                "the existing history record with this id is overwritten with the new description, " +
+                "diffs, and items instead of creating a new history entry — useful when iterating on " +
+                "a walkthrough's content. Leave empty to create a new history record as usual.",
+        ) historyId: String = "",
     ): String {
         val project = requireProject()
         val trimmedDescription = description.trim()
         if (trimmedDescription.isBlank()) mcpFail("description must not be blank")
 
         val parsedPayload = parseDiffPayload(payload)
+
+        val historyService = WalkthroughHistoryService.getInstance(project)
+        val trimmedHistoryId = historyId.trim()
+        if (trimmedHistoryId.isNotBlank()) {
+            historyService.requireOverwritableRecord(trimmedHistoryId, WalkthroughTargetKind.Diff)
+        }
+
         val labeledItems = assignTopLevelLabels(parsedPayload.items)
 
         val session = withContext(Dispatchers.EDT) {
@@ -153,7 +183,8 @@ class ShowWalkthroughItemsToolset : McpToolset {
             )
         } ?: mcpFail("No diff walkthrough items to show")
 
-        val record = WalkthroughHistoryService.getInstance(project).save(
+        val record = historyService.saveOrOverwrite(
+            historyId = trimmedHistoryId,
             description = trimmedDescription,
             targetKind = WalkthroughTargetKind.Diff,
             diffDescriptors = parsedPayload.descriptors,
@@ -373,5 +404,53 @@ class ShowWalkthroughItemsToolset : McpToolset {
         "left" -> DiffSide.Left
         "right" -> DiffSide.Right
         else -> mcpFail("Each diff item must have 'diffSide' set to 'left' or 'right'")
+    }
+}
+
+private fun historyNotFoundMessage(historyId: String) = "No walkthrough history record found for historyId=$historyId"
+
+private fun historyTargetKindMismatchMessage(historyId: String, existingKind: WalkthroughTargetKind) =
+    "historyId=$historyId belongs to a $existingKind walkthrough; use the matching tool to update it"
+
+private fun WalkthroughHistoryService.requireOverwritableRecord(
+    historyId: String,
+    expectedKind: WalkthroughTargetKind,
+) {
+    val record = load(historyId) ?: mcpFail(historyNotFoundMessage(historyId))
+    if (record.targetKind != expectedKind) {
+        mcpFail(historyTargetKindMismatchMessage(historyId, record.targetKind))
+    }
+}
+
+private fun WalkthroughHistoryService.saveOrOverwrite(
+    historyId: String,
+    description: String,
+    targetKind: WalkthroughTargetKind,
+    diffDescriptors: List<DiffWalkthroughDescriptor>,
+    items: List<WalkthroughItem>,
+): WalkthroughRecord? {
+    if (historyId.isBlank()) {
+        return save(
+            description = description,
+            targetKind = targetKind,
+            diffDescriptors = diffDescriptors,
+            items = items,
+        )
+    }
+    return when (
+        val result = overwrite(
+            historyId = historyId,
+            description = description,
+            targetKind = targetKind,
+            diffDescriptors = diffDescriptors,
+            items = items,
+        )
+    ) {
+        is WalkthroughOverwriteResult.Success -> result.record
+
+        WalkthroughOverwriteResult.NotFound -> mcpFail(historyNotFoundMessage(historyId))
+
+        is WalkthroughOverwriteResult.TargetKindMismatch ->
+            mcpFail(historyTargetKindMismatchMessage(historyId, result.existingKind))
     }
 }

--- a/src/main/kotlin/com/forketyfork/walkthrough/ShowWalkthroughItemsToolset.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/ShowWalkthroughItemsToolset.kt
@@ -412,6 +412,9 @@ private fun historyNotFoundMessage(historyId: String) = "No walkthrough history 
 private fun historyTargetKindMismatchMessage(historyId: String, existingKind: WalkthroughTargetKind) =
     "historyId=$historyId belongs to a $existingKind walkthrough; use the matching tool to update it"
 
+private fun historyOverwriteFailureMessage(historyId: String) =
+    "Failed to update walkthrough history record historyId=$historyId; check the IDE log"
+
 private fun WalkthroughHistoryService.requireOverwritableRecord(
     historyId: String,
     expectedKind: WalkthroughTargetKind,
@@ -452,5 +455,7 @@ private fun WalkthroughHistoryService.saveOrOverwrite(
 
         is WalkthroughOverwriteResult.TargetKindMismatch ->
             mcpFail(historyTargetKindMismatchMessage(historyId, result.existingKind))
+
+        WalkthroughOverwriteResult.Failure -> mcpFail(historyOverwriteFailureMessage(historyId))
     }
 }

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughHistoryService.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughHistoryService.kt
@@ -50,6 +50,20 @@ class WalkthroughHistoryService(private val project: Project) {
             }
         }
 
+    internal fun overwrite(
+        historyId: String,
+        description: String,
+        targetKind: WalkthroughTargetKind,
+        diffDescriptors: List<DiffWalkthroughDescriptor>,
+        items: List<WalkthroughItem>,
+    ): WalkthroughOverwriteResult = runHistoryOperation(
+        operation = "overwrite walkthrough history",
+        fallback = WalkthroughOverwriteResult.NotFound,
+    ) {
+        store?.overwrite(historyId, description, targetKind, diffDescriptors, items)
+            ?: WalkthroughOverwriteResult.NotFound
+    }
+
     private fun <T> runHistoryOperation(operation: String, fallback: T, block: () -> T): T =
         runCatching(block).getOrElse { exception ->
             LOG.warn("Failed to $operation", exception)

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughHistoryService.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughHistoryService.kt
@@ -58,7 +58,7 @@ class WalkthroughHistoryService(private val project: Project) {
         items: List<WalkthroughItem>,
     ): WalkthroughOverwriteResult = runHistoryOperation(
         operation = "overwrite walkthrough history",
-        fallback = WalkthroughOverwriteResult.NotFound,
+        fallback = WalkthroughOverwriteResult.Failure,
     ) {
         store?.overwrite(historyId, description, targetKind, diffDescriptors, items)
             ?: WalkthroughOverwriteResult.NotFound

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughHistoryStore.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughHistoryStore.kt
@@ -61,6 +61,7 @@ internal sealed interface WalkthroughOverwriteResult {
     data class Success(val record: WalkthroughRecord) : WalkthroughOverwriteResult
     data object NotFound : WalkthroughOverwriteResult
     data class TargetKindMismatch(val existingKind: WalkthroughTargetKind) : WalkthroughOverwriteResult
+    data object Failure : WalkthroughOverwriteResult
 }
 
 internal class WalkthroughHistoryStore(

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughHistoryStore.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughHistoryStore.kt
@@ -57,6 +57,12 @@ private data class WalkthroughRecordItemJson(
     val parentLabel: String?,
 )
 
+internal sealed interface WalkthroughOverwriteResult {
+    data class Success(val record: WalkthroughRecord) : WalkthroughOverwriteResult
+    data object NotFound : WalkthroughOverwriteResult
+    data class TargetKindMismatch(val existingKind: WalkthroughTargetKind) : WalkthroughOverwriteResult
+}
+
 internal class WalkthroughHistoryStore(
     private val directory: Path,
     private val clock: Clock = Clock.systemUTC(),
@@ -107,6 +113,31 @@ internal class WalkthroughHistoryStore(
             Files.move(temporary, target, ATOMIC_MOVE, REPLACE_EXISTING)
         } catch (_: AtomicMoveNotSupportedException) {
             Files.move(temporary, target, REPLACE_EXISTING)
+        }
+    }
+
+    fun overwrite(
+        historyId: String,
+        description: String,
+        targetKind: WalkthroughTargetKind,
+        diffDescriptors: List<DiffWalkthroughDescriptor>,
+        items: List<WalkthroughItem>,
+    ): WalkthroughOverwriteResult {
+        val existing = load(historyId)
+        return when {
+            existing == null -> WalkthroughOverwriteResult.NotFound
+
+            existing.targetKind != targetKind -> WalkthroughOverwriteResult.TargetKindMismatch(existing.targetKind)
+
+            else -> {
+                val updated = existing.copy(
+                    description = description,
+                    diffDescriptors = diffDescriptors,
+                    items = items,
+                )
+                save(updated)
+                WalkthroughOverwriteResult.Success(updated)
+            }
         }
     }
 

--- a/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughHistoryStoreTest.kt
+++ b/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughHistoryStoreTest.kt
@@ -272,6 +272,97 @@ class WalkthroughHistoryStoreTest {
     }
 
     @Test
+    fun overwritePreservesIdAndCreatedAtAndReplacesDescriptionAndItems() {
+        val store = WalkthroughHistoryStore(
+            directory = tempDir,
+            clock = Clock.fixed(Instant.parse("2026-05-09T04:34:00Z"), ZoneOffset.UTC),
+            randomSuffix = { "abc12345" },
+        )
+        val saved = store.save("Original description", listOf(WalkthroughItem(text = "step one", label = "1")))
+
+        val updatedItems = listOf(
+            WalkthroughItem(text = "step one", label = "1"),
+            WalkthroughItem(text = "step two", label = "2"),
+        )
+        val result = store.overwrite(
+            historyId = saved.id,
+            description = "Updated description",
+            targetKind = WalkthroughTargetKind.File,
+            diffDescriptors = emptyList(),
+            items = updatedItems,
+        )
+
+        check(result is WalkthroughOverwriteResult.Success)
+        assertEquals(saved.id, result.record.id)
+        assertEquals(saved.createdAt, result.record.createdAt)
+        assertEquals("Updated description", result.record.description)
+        assertEquals(updatedItems, result.record.items)
+
+        val reloaded = store.load(saved.id)
+        assertEquals(result.record, reloaded)
+    }
+
+    @Test
+    fun overwriteReturnsNotFoundForUnknownId() {
+        val store = WalkthroughHistoryStore(directory = tempDir)
+
+        val result = store.overwrite(
+            historyId = "20260509-043400-000-missing-abc12345",
+            description = "Updated description",
+            targetKind = WalkthroughTargetKind.File,
+            diffDescriptors = emptyList(),
+            items = listOf(WalkthroughItem(text = "step one")),
+        )
+
+        assertEquals(WalkthroughOverwriteResult.NotFound, result)
+    }
+
+    @Test
+    fun overwriteReturnsNotFoundForUnsafeId() {
+        val store = WalkthroughHistoryStore(directory = tempDir)
+
+        val result = store.overwrite(
+            historyId = "../other-project",
+            description = "Updated description",
+            targetKind = WalkthroughTargetKind.File,
+            diffDescriptors = emptyList(),
+            items = listOf(WalkthroughItem(text = "step one")),
+        )
+
+        assertEquals(WalkthroughOverwriteResult.NotFound, result)
+    }
+
+    @Test
+    fun overwriteReturnsTargetKindMismatchWhenKindDiffers() {
+        val store = WalkthroughHistoryStore(
+            directory = tempDir,
+            clock = Clock.fixed(Instant.parse("2026-05-09T04:34:00Z"), ZoneOffset.UTC),
+            randomSuffix = { "abc12345" },
+        )
+        val saved = store.save("File walkthrough", listOf(WalkthroughItem(text = "step one")))
+
+        val result = store.overwrite(
+            historyId = saved.id,
+            description = "Updated description",
+            targetKind = WalkthroughTargetKind.Diff,
+            diffDescriptors = listOf(
+                DiffWalkthroughDescriptor(
+                    id = "popup-change",
+                    file = "src/Foo.kt",
+                    leftCommit = "1111111111111111111111111111111111111111",
+                    rightCommit = "2222222222222222222222222222222222222222",
+                ),
+            ),
+            items = listOf(
+                WalkthroughItem(text = "step one", line = 1, diffId = "popup-change", diffSide = DiffSide.Right),
+            ),
+        )
+
+        assertEquals(WalkthroughOverwriteResult.TargetKindMismatch(WalkthroughTargetKind.File), result)
+        assertEquals(saved, store.load(saved.id))
+    }
+
+    @Test
     fun saveAcceptsDiffDescriptorWithOnlySideFiles() {
         val store = WalkthroughHistoryStore(
             directory = tempDir,


### PR DESCRIPTION
Closes #49.

## Solution

Iterating on a walkthrough with an agent used to create a new history record on every `show_walkthrough_items` call, and the interim versions had to be deleted by hand. Both show tools now accept an optional `historyId`. When it matches an existing record, that record is overwritten in place: same id, same `createdAt`, new description and items (and diff descriptors for the diff tool). An unknown id, or an id belonging to the other walkthrough kind, fails the call with a clear message before any UI changes happen.

The tool's return message keeps including the history id, so an agent can pass it back on the next call.

## Test plan

- [ ] Show a walkthrough via MCP, note the returned history id, call the tool again with that id and changed steps, and confirm `.idea/walkthroughs/` still has a single file for it with the new content.
- [ ] Pass a made-up `historyId` and confirm the tool fails without opening a popup.
- [ ] Replay the updated walkthrough from Tools > Show Walkthrough History and confirm it shows the latest version.
