### PR TITLE
feat: review pending question tangents when closing a walkthrough (#47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Answer steps inserted for an audience question now stay pending until the walkthrough is
+  closed, when a review prompt lets you keep or discard each question before it is saved to
+  history (#47).
+
 ### Fixed
 
 - Passing an empty or `null` items payload to the walkthrough MCP tools now returns a clear

--- a/src/main/kotlin/com/forketyfork/walkthrough/DiffWalkthroughSession.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/DiffWalkthroughSession.kt
@@ -63,13 +63,22 @@ fun showDiffWalkthroughSession(
         targetKind = WalkthroughTargetKind.Diff,
         diffDescriptors = descriptors,
     )
-    Disposer.register(sessionDisposable) {
-        registry.remove(session.id)
-        registry.clearActive(sessionDisposable)
-    }
 
     var popupRef: WalkthroughPopupSurface? = null
     lateinit var controller: DiffWalkthroughController
+
+    fun performClose() {
+        popupRef = null
+        registry.remove(session.id)
+        Disposer.dispose(sessionDisposable)
+    }
+
+    val closeController = WalkthroughTangentReviewController(project, session, ::performClose)
+    Disposer.register(sessionDisposable) {
+        closeController.persistPendingTangentsOnDispose()
+        registry.remove(session.id)
+        registry.clearActive(sessionDisposable)
+    }
 
     fun updatePopupPalette(palette: WalkthroughPalette) {
         SwingUtilities.invokeLater {
@@ -92,9 +101,11 @@ fun showDiffWalkthroughSession(
         project = project,
         session = session,
         paletteProvider = { paletteState.value },
+        reviewModeProvider = { closeController.reviewModeState.value },
         onItemDisplayed = controller::scheduleItemNavigation,
         onNavigateToSource = controller::scheduleItemNavigation,
         onClose = { popupRef?.cancel() },
+        onConfirmReview = closeController::confirmReview,
     )
     makeComponentHierarchyTransparent(panel)
 
@@ -110,11 +121,7 @@ fun showDiffWalkthroughSession(
     val popup = WalkthroughPopupSurface(
         content = panel,
         palette = paletteState.value,
-        onCloseRequested = {
-            popupRef = null
-            registry.remove(session.id)
-            Disposer.dispose(sessionDisposable)
-        },
+        onCloseRequested = closeController::requestClose,
         onInteractionEnd = { saveCurrentGeometry(popupRef) },
     )
     popupRef = popup

--- a/src/main/kotlin/com/forketyfork/walkthrough/DiffWalkthroughSession.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/DiffWalkthroughSession.kt
@@ -73,12 +73,7 @@ fun showDiffWalkthroughSession(
         Disposer.dispose(sessionDisposable)
     }
 
-    val closeController = WalkthroughTangentReviewController(project, session, ::performClose)
-    Disposer.register(sessionDisposable) {
-        closeController.persistPendingTangentsOnDispose()
-        registry.remove(session.id)
-        registry.clearActive(sessionDisposable)
-    }
+    val closeController = attachTangentReviewController(project, session, sessionDisposable, registry, ::performClose)
 
     fun updatePopupPalette(palette: WalkthroughPalette) {
         SwingUtilities.invokeLater {

--- a/src/main/kotlin/com/forketyfork/walkthrough/ShowWalkthroughItemsToolset.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/ShowWalkthroughItemsToolset.kt
@@ -232,7 +232,9 @@ class ShowWalkthroughItemsToolset : McpToolset {
             "New child labels are derived automatically by appending '.N' to the parent label: " +
             "the first tangent under '3' becomes '3.1', the next '3.2', and so on. The popup " +
             "auto-navigates to the first inserted step. Clears the inline loading spinner so " +
-            "the user can ask another question. After this tool returns, immediately call " +
+            "the user can ask another question. Inserted steps are shown live but stay pending: " +
+            "the user chooses whether to keep or discard each one in a review prompt when they " +
+            "close the walkthrough. After this tool returns, immediately call " +
             "await_walkthrough_question again with the same walkthroughId.",
     )
     suspend fun insertWalkthroughTangents(
@@ -261,9 +263,6 @@ class ShowWalkthroughItemsToolset : McpToolset {
 
         val inserted = withContext(Dispatchers.EDT) {
             session.insertTangents(trimmedParent, parsedItems)
-        }
-        session.historyRecordId?.let { recordId ->
-            WalkthroughHistoryService.getInstance(project).updateItems(recordId, session.snapshotItems())
         }
         val labels = inserted.mapNotNull { it.label }.joinToString(", ")
         return "Inserted ${inserted.size} tangent step(s) under $trimmedParent: $labels"

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughOrchestrator.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughOrchestrator.kt
@@ -49,14 +49,23 @@ fun showWalkthroughSession(
     val registry = WalkthroughSessionRegistry.getInstance(project)
     registry.swapActive(sessionDisposable)?.let(Disposer::dispose)
     val session = registry.create(items, acceptsQuestions)
-    Disposer.register(sessionDisposable) {
-        registry.remove(session.id)
-        registry.clearActive(sessionDisposable)
-    }
 
     var popupRef: WalkthroughPopupSurface? = null
     var currentEditor = firstTarget.editor
     var pendingNavigationId = 0
+
+    fun performClose() {
+        popupRef = null
+        registry.remove(session.id)
+        Disposer.dispose(sessionDisposable)
+    }
+
+    val closeController = WalkthroughTangentReviewController(project, session, ::performClose)
+    Disposer.register(sessionDisposable) {
+        closeController.persistPendingTangentsOnDispose()
+        registry.remove(session.id)
+        registry.clearActive(sessionDisposable)
+    }
 
     fun repaintPopup() {
         popupRef?.let { popup ->
@@ -99,9 +108,11 @@ fun showWalkthroughSession(
         project = project,
         session = session,
         paletteProvider = { paletteState.value },
+        reviewModeProvider = { closeController.reviewModeState.value },
         onItemDisplayed = ::scheduleItemNavigation,
         onNavigateToSource = ::scheduleItemNavigation,
         onClose = { popupRef?.cancel() },
+        onConfirmReview = closeController::confirmReview,
     )
     makeComponentHierarchyTransparent(panel)
 
@@ -126,11 +137,7 @@ fun showWalkthroughSession(
     val popup = WalkthroughPopupSurface(
         content = panel,
         palette = paletteState.value,
-        onCloseRequested = {
-            popupRef = null
-            registry.remove(session.id)
-            Disposer.dispose(sessionDisposable)
-        },
+        onCloseRequested = closeController::requestClose,
         onInteractionEnd = { saveCurrentGeometry(popupRef) },
     )
     popupRef = popup
@@ -187,17 +194,21 @@ internal fun createWalkthroughPanel(
     project: Project,
     session: WalkthroughSession,
     paletteProvider: () -> WalkthroughPalette,
+    reviewModeProvider: () -> Boolean,
     onItemDisplayed: (WalkthroughItem) -> Unit,
     onNavigateToSource: (WalkthroughItem) -> Unit,
     onClose: () -> Unit,
+    onConfirmReview: (Set<String>) -> Unit,
 ): JComponent = JewelComposePanel {
     WalkthroughItemContent(
         project = project,
         session = session,
         palette = paletteProvider(),
+        reviewMode = reviewModeProvider(),
         onItemDisplay = onItemDisplayed,
         onNavigateToSource = onNavigateToSource,
         onClose = onClose,
+        onConfirmReview = onConfirmReview,
     )
 }.apply {
     isOpaque = false

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughOrchestrator.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughOrchestrator.kt
@@ -60,12 +60,7 @@ fun showWalkthroughSession(
         Disposer.dispose(sessionDisposable)
     }
 
-    val closeController = WalkthroughTangentReviewController(project, session, ::performClose)
-    Disposer.register(sessionDisposable) {
-        closeController.persistPendingTangentsOnDispose()
-        registry.remove(session.id)
-        registry.clearActive(sessionDisposable)
-    }
+    val closeController = attachTangentReviewController(project, session, sessionDisposable, registry, ::performClose)
 
     fun repaintPopup() {
         popupRef?.let { popup ->

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupContent.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupContent.kt
@@ -41,6 +41,8 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.intellij.openapi.project.Project
@@ -99,9 +101,9 @@ private object WalkthroughPopupContentStyle {
     val scrollbarPaddingEnd = 6.dp
     val scrollbarPaddingTop = 10.dp
     val scrollbarPaddingBottom = 10.dp
-    val reviewTitleTextSize = 15.sp
-    val reviewButtonRowSpacing = 10.dp
-    val reviewQuestionListSpacing = 10.dp
+    val reviewTitleTextSize: TextUnit = 15.sp
+    val reviewButtonRowSpacing: Dp = 10.dp
+    val reviewQuestionListSpacing: Dp = 10.dp
 }
 
 private data class WalkthroughPopupAnimationState(val gradientShift: Float, val glowShift: Float)
@@ -120,9 +122,8 @@ internal fun WalkthroughItemContent(
 ) {
     val animationState = rememberPopupAnimationState()
     if (reviewMode) {
-        val groups = remember(session) { session.pendingTangentGroups.toList() }
         WalkthroughTangentReviewFrame(
-            groups = groups,
+            session = session,
             palette = palette,
             animationState = animationState,
             onClose = onClose,
@@ -285,17 +286,24 @@ private fun WalkthroughPopupFrame(
     }
 }
 
+/**
+ * Renders the tangent review screen. Reads [WalkthroughSession.pendingTangentGroups] directly
+ * (a [androidx.compose.runtime.snapshots.SnapshotStateList]) rather than a one-shot snapshot copy,
+ * so a group inserted by the agent while this screen is already open shows up as a new row instead
+ * of being silently discarded when the user confirms.
+ */
 @Composable
 private fun WalkthroughTangentReviewFrame(
-    groups: List<WalkthroughPendingTangentGroup>,
+    session: WalkthroughSession,
     palette: WalkthroughPalette,
     animationState: WalkthroughPopupAnimationState,
     onClose: () -> Unit,
     onConfirm: (Set<String>) -> Unit,
 ) {
-    val keptGroupIds = remember(groups) {
-        mutableStateMapOf<String, Boolean>().apply { groups.forEach { put(it.id, true) } }
-    }
+    val groups = session.pendingTangentGroups
+    // Keyed on the session, not the (live) group list, so existing checkbox choices survive a
+    // late-arriving group being appended. A group missing from this map defaults to kept.
+    val discardedGroupIds = remember(session) { mutableStateMapOf<String, Boolean>() }
     val shape = RoundedCornerShape(WalkthroughPopupContentStyle.cornerRadius)
     Box(
         modifier = Modifier
@@ -326,10 +334,24 @@ private fun WalkthroughTangentReviewFrame(
                 fontWeight = FontWeight.SemiBold,
                 fontSize = WalkthroughPopupContentStyle.reviewTitleTextSize,
             )
-            WalkthroughTangentReviewList(groups = groups, keptGroupIds = keptGroupIds)
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f, fill = true)
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(WalkthroughPopupContentStyle.reviewQuestionListSpacing),
+            ) {
+                groups.forEach { group ->
+                    WalkthroughTangentReviewRow(
+                        question = group.questionText,
+                        checked = discardedGroupIds[group.id] != true,
+                        onToggle = { discardedGroupIds[group.id] = discardedGroupIds[group.id] != true },
+                    )
+                }
+            }
             WalkthroughTangentReviewActions(
                 groups = groups,
-                keptGroupIds = keptGroupIds,
+                discardedGroupIds = discardedGroupIds,
                 palette = palette,
                 onConfirm = onConfirm,
             )
@@ -338,31 +360,9 @@ private fun WalkthroughTangentReviewFrame(
 }
 
 @Composable
-private fun ColumnScope.WalkthroughTangentReviewList(
-    groups: List<WalkthroughPendingTangentGroup>,
-    keptGroupIds: SnapshotStateMap<String, Boolean>,
-) {
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .weight(1f, fill = true)
-            .verticalScroll(rememberScrollState()),
-        verticalArrangement = Arrangement.spacedBy(WalkthroughPopupContentStyle.reviewQuestionListSpacing),
-    ) {
-        groups.forEach { group ->
-            WalkthroughTangentReviewRow(
-                question = group.questionText,
-                checked = keptGroupIds[group.id] == true,
-                onToggle = { keptGroupIds[group.id] = keptGroupIds[group.id] != true },
-            )
-        }
-    }
-}
-
-@Composable
 private fun WalkthroughTangentReviewActions(
     groups: List<WalkthroughPendingTangentGroup>,
-    keptGroupIds: SnapshotStateMap<String, Boolean>,
+    discardedGroupIds: SnapshotStateMap<String, Boolean>,
     palette: WalkthroughPalette,
     onConfirm: (Set<String>) -> Unit,
 ) {
@@ -375,21 +375,21 @@ private fun WalkthroughTangentReviewActions(
             enabled = true,
             emphasized = false,
             palette = palette,
-            onClick = { groups.forEach { keptGroupIds[it.id] = true } },
+            onClick = { groups.forEach { discardedGroupIds[it.id] = false } },
         )
         AiNavButton(
             label = "Discard all",
             enabled = true,
             emphasized = false,
             palette = palette,
-            onClick = { groups.forEach { keptGroupIds[it.id] = false } },
+            onClick = { groups.forEach { discardedGroupIds[it.id] = true } },
         )
         AiNavButton(
             label = "Done",
             enabled = true,
             emphasized = true,
             palette = palette,
-            onClick = { onConfirm(keptGroupIds.filterValues { it }.keys) },
+            onClick = { onConfirm(groups.filter { discardedGroupIds[it.id] == true }.map { it.id }.toSet()) },
         )
     }
 }

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupContent.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupContent.kt
@@ -25,10 +25,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshots.SnapshotStateMap
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -97,6 +99,9 @@ private object WalkthroughPopupContentStyle {
     val scrollbarPaddingEnd = 6.dp
     val scrollbarPaddingTop = 10.dp
     val scrollbarPaddingBottom = 10.dp
+    val reviewTitleTextSize = 15.sp
+    val reviewButtonRowSpacing = 10.dp
+    val reviewQuestionListSpacing = 10.dp
 }
 
 private data class WalkthroughPopupAnimationState(val gradientShift: Float, val glowShift: Float)
@@ -107,16 +112,30 @@ internal fun WalkthroughItemContent(
     project: Project,
     session: WalkthroughSession,
     palette: WalkthroughPalette,
+    reviewMode: Boolean,
     onItemDisplay: (WalkthroughItem) -> Unit,
     onNavigateToSource: (WalkthroughItem) -> Unit,
     onClose: () -> Unit,
+    onConfirmReview: (Set<String>) -> Unit,
 ) {
+    val animationState = rememberPopupAnimationState()
+    if (reviewMode) {
+        val groups = remember(session) { session.pendingTangentGroups.toList() }
+        WalkthroughTangentReviewFrame(
+            groups = groups,
+            palette = palette,
+            animationState = animationState,
+            onClose = onClose,
+            onConfirm = onConfirmReview,
+        )
+        return
+    }
+
     val items = session.items
     var currentIndex by session.currentIndexState
     val safeIndex = currentIndex.coerceIn(0, (items.size - 1).coerceAtLeast(0))
     val item = items.getOrNull(safeIndex) ?: return
     val scrollState = rememberScrollState()
-    val animationState = rememberPopupAnimationState()
     val scrollbarStyle = rememberPopupScrollbarStyle(palette)
     val showScrollbar = scrollState.maxValue > 0
     val questionStatus by session.questionStatusState
@@ -263,6 +282,115 @@ private fun WalkthroughPopupFrame(
                 )
             }
         }
+    }
+}
+
+@Composable
+private fun WalkthroughTangentReviewFrame(
+    groups: List<WalkthroughPendingTangentGroup>,
+    palette: WalkthroughPalette,
+    animationState: WalkthroughPopupAnimationState,
+    onClose: () -> Unit,
+    onConfirm: (Set<String>) -> Unit,
+) {
+    val keptGroupIds = remember(groups) {
+        mutableStateMapOf<String, Boolean>().apply { groups.forEach { put(it.id, true) } }
+    }
+    val shape = RoundedCornerShape(WalkthroughPopupContentStyle.cornerRadius)
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .clip(shape)
+            .walkthroughPopupBackground(animationState, palette),
+    ) {
+        AiCloseButton(
+            modifier = Modifier
+                .align(Alignment.TopEnd)
+                .padding(WalkthroughPopupContentStyle.closeButtonPadding),
+            onClick = onClose,
+        )
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(
+                    start = WalkthroughPopupContentStyle.contentPaddingStart,
+                    top = WalkthroughPopupContentStyle.contentPaddingTop,
+                    end = WalkthroughPopupContentStyle.contentPaddingEnd,
+                    bottom = WalkthroughPopupContentStyle.contentPaddingBottom,
+                ),
+            verticalArrangement = Arrangement.spacedBy(WalkthroughPopupContentStyle.contentSectionSpacing),
+        ) {
+            Text(
+                text = "Keep questions in this walkthrough?",
+                color = Color.White,
+                fontWeight = FontWeight.SemiBold,
+                fontSize = WalkthroughPopupContentStyle.reviewTitleTextSize,
+            )
+            WalkthroughTangentReviewList(groups = groups, keptGroupIds = keptGroupIds)
+            WalkthroughTangentReviewActions(
+                groups = groups,
+                keptGroupIds = keptGroupIds,
+                palette = palette,
+                onConfirm = onConfirm,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ColumnScope.WalkthroughTangentReviewList(
+    groups: List<WalkthroughPendingTangentGroup>,
+    keptGroupIds: SnapshotStateMap<String, Boolean>,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .weight(1f, fill = true)
+            .verticalScroll(rememberScrollState()),
+        verticalArrangement = Arrangement.spacedBy(WalkthroughPopupContentStyle.reviewQuestionListSpacing),
+    ) {
+        groups.forEach { group ->
+            WalkthroughTangentReviewRow(
+                question = group.questionText,
+                checked = keptGroupIds[group.id] == true,
+                onToggle = { keptGroupIds[group.id] = keptGroupIds[group.id] != true },
+            )
+        }
+    }
+}
+
+@Composable
+private fun WalkthroughTangentReviewActions(
+    groups: List<WalkthroughPendingTangentGroup>,
+    keptGroupIds: SnapshotStateMap<String, Boolean>,
+    palette: WalkthroughPalette,
+    onConfirm: (Set<String>) -> Unit,
+) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(WalkthroughPopupContentStyle.reviewButtonRowSpacing),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        AiNavButton(
+            label = "Keep all",
+            enabled = true,
+            emphasized = false,
+            palette = palette,
+            onClick = { groups.forEach { keptGroupIds[it.id] = true } },
+        )
+        AiNavButton(
+            label = "Discard all",
+            enabled = true,
+            emphasized = false,
+            palette = palette,
+            onClick = { groups.forEach { keptGroupIds[it.id] = false } },
+        )
+        AiNavButton(
+            label = "Done",
+            enabled = true,
+            emphasized = true,
+            palette = palette,
+            onClick = { onConfirm(keptGroupIds.filterValues { it }.keys) },
+        )
     }
 }
 

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupWidgets.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupWidgets.kt
@@ -43,6 +43,8 @@ import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.jetbrains.jewel.ui.component.Icon
@@ -83,11 +85,11 @@ private object WalkthroughWidgetStyle {
     const val SPINNER_SWEEP_DEGREES = 270f
     const val SPINNER_ROTATION_DURATION_MS = 1000
     const val SPINNER_TRACK_ALPHA = 0.18f
-    val reviewRowSpacing = 12.dp
-    val reviewCheckboxSize = 20.dp
-    val reviewCheckboxCornerRadius = 5.dp
+    val reviewRowSpacing: Dp = 12.dp
+    val reviewCheckboxSize: Dp = 20.dp
+    val reviewCheckboxCornerRadius: Dp = 5.dp
     const val REVIEW_CHECKBOX_CHECKED_ALPHA = 0.92f
-    val reviewCheckmarkTextSize = 13.sp
+    val reviewCheckmarkTextSize: TextUnit = 13.sp
 }
 
 @Suppress("LongParameterList")

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupWidgets.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupWidgets.kt
@@ -83,6 +83,11 @@ private object WalkthroughWidgetStyle {
     const val SPINNER_SWEEP_DEGREES = 270f
     const val SPINNER_ROTATION_DURATION_MS = 1000
     const val SPINNER_TRACK_ALPHA = 0.18f
+    val reviewRowSpacing = 12.dp
+    val reviewCheckboxSize = 20.dp
+    val reviewCheckboxCornerRadius = 5.dp
+    const val REVIEW_CHECKBOX_CHECKED_ALPHA = 0.92f
+    val reviewCheckmarkTextSize = 13.sp
 }
 
 @Suppress("LongParameterList")
@@ -407,6 +412,53 @@ private fun QuestionSpinner(palette: WalkthroughPalette) {
     ) {
         Canvas(modifier = Modifier.size(WalkthroughWidgetStyle.spinnerSize).rotate(rotation)) {
             drawSpinnerArc(palette = palette)
+        }
+    }
+}
+
+@Composable
+internal fun WalkthroughTangentReviewRow(question: String, checked: Boolean, onToggle: () -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth().clickable(onClick = onToggle),
+        horizontalArrangement = Arrangement.spacedBy(WalkthroughWidgetStyle.reviewRowSpacing),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        WalkthroughTangentReviewCheckbox(checked = checked)
+        Text(
+            text = question,
+            color = Color.White,
+            fontSize = WalkthroughWidgetStyle.questionFieldTextSize,
+        )
+    }
+}
+
+@Composable
+private fun WalkthroughTangentReviewCheckbox(checked: Boolean) {
+    Box(
+        modifier = Modifier
+            .size(WalkthroughWidgetStyle.reviewCheckboxSize)
+            .clip(RoundedCornerShape(WalkthroughWidgetStyle.reviewCheckboxCornerRadius))
+            .background(
+                if (checked) {
+                    Color.White.copy(alpha = WalkthroughWidgetStyle.REVIEW_CHECKBOX_CHECKED_ALPHA)
+                } else {
+                    Color.White.copy(alpha = WalkthroughWidgetStyle.CLOSE_BUTTON_BACKGROUND_ALPHA)
+                },
+            )
+            .border(
+                WalkthroughWidgetStyle.closeButtonBorderWidth,
+                Color.White.copy(alpha = WalkthroughWidgetStyle.CLOSE_BUTTON_BORDER_ALPHA),
+                RoundedCornerShape(WalkthroughWidgetStyle.reviewCheckboxCornerRadius),
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        if (checked) {
+            Text(
+                text = "✓",
+                color = Color.Black,
+                fontWeight = FontWeight.Bold,
+                fontSize = WalkthroughWidgetStyle.reviewCheckmarkTextSize,
+            )
         }
     }
 }

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughSessionRegistry.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughSessionRegistry.kt
@@ -20,6 +20,13 @@ import java.util.concurrent.atomic.AtomicReference
 
 data class WalkthroughTangentQuestion(val question: String, val parentLabel: String?)
 
+data class WalkthroughPendingTangentGroup(
+    val id: String,
+    val questionText: String,
+    val parentLabel: String,
+    val childLabels: List<String>,
+)
+
 internal enum class WalkthroughQuestionStatus {
     AgentNotWaiting,
     WaitingForQuestion,
@@ -55,6 +62,7 @@ class WalkthroughSession internal constructor(
 ) {
     internal val items: SnapshotStateList<WalkthroughItem> =
         mutableStateListOf<WalkthroughItem>().apply { addAll(initialItems) }
+    internal val pendingTangentGroups: SnapshotStateList<WalkthroughPendingTangentGroup> = mutableStateListOf()
     internal val currentIndexState = mutableIntStateOf(0)
     internal val questionStatusState = mutableStateOf(WalkthroughQuestionStatus.AgentNotWaiting)
     internal val loadingState = mutableStateOf(false)
@@ -155,12 +163,47 @@ class WalkthroughSession internal constructor(
         }
         items.addAll(lastSubtreeIndex + 1, labeled)
         currentIndexState.intValue = lastSubtreeIndex + 1
-        synchronized(questionLock) {
+        val questionText = synchronized(questionLock) {
+            val text = inFlightQuestion?.question
             inFlightQuestion = null
             scheduleAgentNotWaitingLocked()
+            text
         }
+        pendingTangentGroups.add(
+            WalkthroughPendingTangentGroup(
+                id = UUID.randomUUID().toString(),
+                questionText = questionText ?: parentLabel,
+                parentLabel = parentLabel,
+                childLabels = labeled.mapNotNull { it.label },
+            ),
+        )
         return labeled
     }
+
+    /**
+     * Applies a review decision for the currently pending tangent groups: groups in [keptGroupIds]
+     * stay in [items], the rest have their child steps removed. Clears the pending groups either way.
+     * Returns whether any group was kept, i.e. whether the caller must persist [items] to history.
+     */
+    internal fun applyTangentReviewDecision(keptGroupIds: Set<String>): Boolean {
+        val groups = pendingTangentGroups.toList()
+        if (groups.isEmpty()) return false
+        val discardedLabels = groups.filterNot { it.id in keptGroupIds }
+            .flatMap { it.childLabels }
+            .toSet()
+        if (discardedLabels.isNotEmpty()) {
+            items.removeAll { it.label in discardedLabels }
+        }
+        pendingTangentGroups.clear()
+        return groups.any { it.id in keptGroupIds }
+    }
+
+    /**
+     * Non-destructive fallback for when a session ends without an explicit review decision: keeps
+     * every pending tangent group. A no-op if a decision was already applied.
+     */
+    internal fun keepAllPendingTangents(): Boolean =
+        applyTangentReviewDecision(pendingTangentGroups.map { it.id }.toSet())
 
     internal fun dismiss() {
         if (disposed.complete(Unit)) {

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughSessionRegistry.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughSessionRegistry.kt
@@ -181,29 +181,54 @@ class WalkthroughSession internal constructor(
     }
 
     /**
-     * Applies a review decision for the currently pending tangent groups: groups in [keptGroupIds]
-     * stay in [items], the rest have their child steps removed. Clears the pending groups either way.
+     * Applies a review decision for the currently pending tangent groups: groups in
+     * [discardedGroupIds] have their child steps removed from [items], the rest stay. A pending
+     * group whose [parentLabel][WalkthroughPendingTangentGroup.parentLabel] falls under a
+     * discarded group's subtree is discarded too, even if its own id is absent from
+     * [discardedGroupIds] — this cascades the removal to nested tangents (asked on a
+     * still-pending tangent step) whose parent no longer exists. Any pending group unknown to the
+     * caller — e.g. one inserted while the review screen was already open — defaults to kept.
+     * Clears the pending groups either way.
      * Returns whether any group was kept, i.e. whether the caller must persist [items] to history.
      */
-    internal fun applyTangentReviewDecision(keptGroupIds: Set<String>): Boolean {
+    internal fun applyTangentReviewDecision(discardedGroupIds: Set<String>): Boolean {
         val groups = pendingTangentGroups.toList()
         if (groups.isEmpty()) return false
-        val discardedLabels = groups.filterNot { it.id in keptGroupIds }
-            .flatMap { it.childLabels }
-            .toSet()
+
+        val resolvedDiscardedIds = mutableSetOf<String>()
+        val discardedLabels = mutableSetOf<String>()
+
+        fun isUnderDiscardedSubtree(label: String) = discardedLabels.any { label == it || label.startsWith("$it.") }
+
+        groups.filter { it.id in discardedGroupIds }.forEach { group ->
+            resolvedDiscardedIds += group.id
+            discardedLabels += group.childLabels
+        }
+
+        var cascaded = true
+        while (cascaded) {
+            cascaded = false
+            groups.forEach { group ->
+                if (group.id !in resolvedDiscardedIds && isUnderDiscardedSubtree(group.parentLabel)) {
+                    resolvedDiscardedIds += group.id
+                    discardedLabels += group.childLabels
+                    cascaded = true
+                }
+            }
+        }
+
         if (discardedLabels.isNotEmpty()) {
-            items.removeAll { it.label in discardedLabels }
+            items.removeAll { item -> item.label != null && isUnderDiscardedSubtree(item.label) }
         }
         pendingTangentGroups.clear()
-        return groups.any { it.id in keptGroupIds }
+        return groups.any { it.id !in resolvedDiscardedIds }
     }
 
     /**
      * Non-destructive fallback for when a session ends without an explicit review decision: keeps
      * every pending tangent group. A no-op if a decision was already applied.
      */
-    internal fun keepAllPendingTangents(): Boolean =
-        applyTangentReviewDecision(pendingTangentGroups.map { it.id }.toSet())
+    internal fun keepAllPendingTangents(): Boolean = applyTangentReviewDecision(discardedGroupIds = emptySet())
 
     internal fun dismiss() {
         if (disposed.complete(Unit)) {

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughTangentReviewController.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughTangentReviewController.kt
@@ -1,14 +1,18 @@
 package com.forketyfork.walkthrough
 
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Disposer
 
 internal class WalkthroughTangentReviewController(
     private val project: Project,
     private val session: WalkthroughSession,
     private val performClose: () -> Unit,
 ) {
-    val reviewModeState = mutableStateOf(false)
+    val reviewModeState: MutableState<Boolean> = mutableStateOf(false)
 
     fun requestClose() {
         if (!reviewModeState.value && hasPendingTangentReview()) {
@@ -18,8 +22,8 @@ internal class WalkthroughTangentReviewController(
         performClose()
     }
 
-    fun confirmReview(keptGroupIds: Set<String>) {
-        persistIfNeeded(session.applyTangentReviewDecision(keptGroupIds))
+    fun confirmReview(discardedGroupIds: Set<String>) {
+        persistIfNeeded(session.applyTangentReviewDecision(discardedGroupIds))
         performClose()
     }
 
@@ -29,11 +33,37 @@ internal class WalkthroughTangentReviewController(
 
     private fun persistIfNeeded(shouldPersist: Boolean) {
         if (!shouldPersist) return
-        session.historyRecordId?.let { recordId ->
-            WalkthroughHistoryService.getInstance(project).updateItems(recordId, session.snapshotItems())
+        val recordId = session.historyRecordId ?: return
+        // Snapshot on the calling thread (typically the EDT), then move the load+write file IO
+        // off it so closing or reviewing a walkthrough never blocks the UI thread.
+        val itemsSnapshot = session.snapshotItems()
+        ApplicationManager.getApplication().executeOnPooledThread {
+            WalkthroughHistoryService.getInstance(project).updateItems(recordId, itemsSnapshot)
         }
     }
 
     private fun hasPendingTangentReview(): Boolean =
         session.acceptsQuestions && session.historyRecordId != null && session.pendingTangentGroups.isNotEmpty()
+}
+
+/**
+ * Creates the [WalkthroughTangentReviewController] for a walkthrough session and wires its
+ * disposal-time fallback (keep all pending tangents, then remove the session from [registry]).
+ * Shared by [showWalkthroughSession] and [showDiffWalkthroughSession], which otherwise duplicate
+ * this wiring identically.
+ */
+internal fun attachTangentReviewController(
+    project: Project,
+    session: WalkthroughSession,
+    sessionDisposable: Disposable,
+    registry: WalkthroughSessionRegistry,
+    performClose: () -> Unit,
+): WalkthroughTangentReviewController {
+    val controller = WalkthroughTangentReviewController(project, session, performClose)
+    Disposer.register(sessionDisposable) {
+        controller.persistPendingTangentsOnDispose()
+        registry.remove(session.id)
+        registry.clearActive(sessionDisposable)
+    }
+    return controller
 }

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughTangentReviewController.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughTangentReviewController.kt
@@ -1,0 +1,39 @@
+package com.forketyfork.walkthrough
+
+import androidx.compose.runtime.mutableStateOf
+import com.intellij.openapi.project.Project
+
+internal class WalkthroughTangentReviewController(
+    private val project: Project,
+    private val session: WalkthroughSession,
+    private val performClose: () -> Unit,
+) {
+    val reviewModeState = mutableStateOf(false)
+
+    fun requestClose() {
+        if (!reviewModeState.value && hasPendingTangentReview()) {
+            reviewModeState.value = true
+            return
+        }
+        performClose()
+    }
+
+    fun confirmReview(keptGroupIds: Set<String>) {
+        persistIfNeeded(session.applyTangentReviewDecision(keptGroupIds))
+        performClose()
+    }
+
+    fun persistPendingTangentsOnDispose() {
+        persistIfNeeded(session.keepAllPendingTangents())
+    }
+
+    private fun persistIfNeeded(shouldPersist: Boolean) {
+        if (!shouldPersist) return
+        session.historyRecordId?.let { recordId ->
+            WalkthroughHistoryService.getInstance(project).updateItems(recordId, session.snapshotItems())
+        }
+    }
+
+    private fun hasPendingTangentReview(): Boolean =
+        session.acceptsQuestions && session.historyRecordId != null && session.pendingTangentGroups.isNotEmpty()
+}

--- a/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughSessionRegistryTest.kt
+++ b/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughSessionRegistryTest.kt
@@ -139,7 +139,7 @@ class WalkthroughSessionRegistryTest {
         val groups = session.pendingTangentGroups.toList()
         assertEquals(2, groups.size)
 
-        val shouldPersist = session.applyTangentReviewDecision(setOf(groups[1].id))
+        val shouldPersist = session.applyTangentReviewDecision(setOf(groups[0].id))
 
         assertTrue(shouldPersist)
         assertEquals(
@@ -150,13 +150,14 @@ class WalkthroughSessionRegistryTest {
     }
 
     @Test
-    fun applyTangentReviewDecisionWithNoKeptGroupsRemovesAllTangentsWithoutRequiringPersistence() {
+    fun applyTangentReviewDecisionDiscardingAllGroupsRemovesAllTangentsWithoutRequiringPersistence() {
         val session = newSession(
             assignTopLevelLabels(listOf(WalkthroughItem(text = "only"))),
         )
         session.insertTangents("1", listOf(WalkthroughItem(text = "answer")))
+        val groupId = session.pendingTangentGroups.single().id
 
-        val shouldPersist = session.applyTangentReviewDecision(emptySet())
+        val shouldPersist = session.applyTangentReviewDecision(setOf(groupId))
 
         assertFalse(shouldPersist)
         assertEquals(listOf("1"), session.snapshotItems().map { it.label })
@@ -173,6 +174,53 @@ class WalkthroughSessionRegistryTest {
 
         assertFalse(shouldPersist)
         assertEquals(listOf("1"), session.snapshotItems().map { it.label })
+    }
+
+    @Test
+    fun applyTangentReviewDecisionWithUnknownGroupIdDefaultsToKeepingEverything() {
+        val session = newSession(
+            assignTopLevelLabels(listOf(WalkthroughItem(text = "only"))),
+        )
+        session.insertTangents("1", listOf(WalkthroughItem(text = "answer")))
+
+        val shouldPersist = session.applyTangentReviewDecision(setOf("late-arrival-not-yet-visible"))
+
+        assertTrue(shouldPersist)
+        assertEquals(listOf("1", "1.1"), session.snapshotItems().map { it.label })
+        assertTrue(session.pendingTangentGroups.isEmpty())
+    }
+
+    @Test
+    fun applyTangentReviewDecisionCascadesDiscardToNestedGroupUnderDiscardedParent() {
+        val session = newSession(
+            assignTopLevelLabels(listOf(WalkthroughItem(text = "root"))),
+        )
+        session.insertTangents("1", listOf(WalkthroughItem(text = "child")))
+        session.insertTangents("1.1", listOf(WalkthroughItem(text = "grandchild")))
+        val parentGroup = session.pendingTangentGroups.single { it.parentLabel == "1" }
+
+        // Only the parent group is explicitly discarded; the nested group under "1.1" is not
+        // mentioned, but it must be discarded too since its parent step no longer exists.
+        val shouldPersist = session.applyTangentReviewDecision(setOf(parentGroup.id))
+
+        assertFalse(shouldPersist)
+        assertEquals(listOf("1"), session.snapshotItems().map { it.label })
+        assertTrue(session.pendingTangentGroups.isEmpty())
+    }
+
+    @Test
+    fun applyTangentReviewDecisionKeepsNestedGroupWhenParentGroupIsKept() {
+        val session = newSession(
+            assignTopLevelLabels(listOf(WalkthroughItem(text = "root"))),
+        )
+        session.insertTangents("1", listOf(WalkthroughItem(text = "child")))
+        session.insertTangents("1.1", listOf(WalkthroughItem(text = "grandchild")))
+
+        val shouldPersist = session.applyTangentReviewDecision(emptySet())
+
+        assertTrue(shouldPersist)
+        assertEquals(listOf("1", "1.1", "1.1.1"), session.snapshotItems().map { it.label })
+        assertTrue(session.pendingTangentGroups.isEmpty())
     }
 
     @Test

--- a/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughSessionRegistryTest.kt
+++ b/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughSessionRegistryTest.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.yield
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertSame
@@ -97,6 +98,95 @@ class WalkthroughSessionRegistryTest {
             listOf("1", "1.1", "1.1.1"),
             session.snapshotItems().map { it.label },
         )
+    }
+
+    @Test
+    fun insertTangentsAssociatesPendingGroupWithInFlightQuestionText() = runBlocking {
+        val session = newSession(
+            assignTopLevelLabels(listOf(WalkthroughItem(text = "only"))),
+        )
+        session.submitQuestion("what does this do?")
+        session.awaitQuestionResult(timeoutMillis = TEST_AWAIT_TIMEOUT_MILLIS)
+
+        session.insertTangents("1", listOf(WalkthroughItem(text = "answer")))
+
+        val group = session.pendingTangentGroups.single()
+        assertEquals("what does this do?", group.questionText)
+        assertEquals("1", group.parentLabel)
+        assertEquals(listOf("1.1"), group.childLabels)
+    }
+
+    @Test
+    fun insertTangentsFallsBackToParentLabelWithoutAnInFlightQuestion() {
+        val session = newSession(
+            assignTopLevelLabels(listOf(WalkthroughItem(text = "only"))),
+        )
+
+        session.insertTangents("1", listOf(WalkthroughItem(text = "answer")))
+
+        assertEquals("1", session.pendingTangentGroups.single().questionText)
+    }
+
+    @Test
+    fun applyTangentReviewDecisionPreservesOrderAndLabelsOfSurvivingItems() {
+        val session = newSession(
+            assignTopLevelLabels(
+                listOf(WalkthroughItem(text = "one"), WalkthroughItem(text = "two"), WalkthroughItem(text = "three")),
+            ),
+        )
+        session.insertTangents("1", listOf(WalkthroughItem(text = "a1"), WalkthroughItem(text = "a2")))
+        session.insertTangents("2", listOf(WalkthroughItem(text = "b1")))
+        val groups = session.pendingTangentGroups.toList()
+        assertEquals(2, groups.size)
+
+        val shouldPersist = session.applyTangentReviewDecision(setOf(groups[1].id))
+
+        assertTrue(shouldPersist)
+        assertEquals(
+            listOf("1", "2", "2.1", "3"),
+            session.snapshotItems().map { it.label },
+        )
+        assertTrue(session.pendingTangentGroups.isEmpty())
+    }
+
+    @Test
+    fun applyTangentReviewDecisionWithNoKeptGroupsRemovesAllTangentsWithoutRequiringPersistence() {
+        val session = newSession(
+            assignTopLevelLabels(listOf(WalkthroughItem(text = "only"))),
+        )
+        session.insertTangents("1", listOf(WalkthroughItem(text = "answer")))
+
+        val shouldPersist = session.applyTangentReviewDecision(emptySet())
+
+        assertFalse(shouldPersist)
+        assertEquals(listOf("1"), session.snapshotItems().map { it.label })
+        assertTrue(session.pendingTangentGroups.isEmpty())
+    }
+
+    @Test
+    fun applyTangentReviewDecisionWithNoPendingGroupsIsANoOp() {
+        val session = newSession(
+            assignTopLevelLabels(listOf(WalkthroughItem(text = "only"))),
+        )
+
+        val shouldPersist = session.applyTangentReviewDecision(setOf("nonexistent"))
+
+        assertFalse(shouldPersist)
+        assertEquals(listOf("1"), session.snapshotItems().map { it.label })
+    }
+
+    @Test
+    fun keepAllPendingTangentsPersistsEveryGroupAndIsIdempotent() {
+        val session = newSession(
+            assignTopLevelLabels(listOf(WalkthroughItem(text = "only"))),
+        )
+        session.insertTangents("1", listOf(WalkthroughItem(text = "answer")))
+
+        assertTrue(session.keepAllPendingTangents())
+        assertEquals(listOf("1", "1.1"), session.snapshotItems().map { it.label })
+        assertTrue(session.pendingTangentGroups.isEmpty())
+
+        assertFalse(session.keepAllPendingTangents())
     }
 
     @Test


### PR DESCRIPTION
Closes #47. Replaces #53.

## Solution

The first attempt (#53) added a `persistTangents` flag to the show tools, but that put the persistence decision in the wrong place: an agent had to infer it from the user's prompt, and when it guessed "immutable" the user would see answer steps that silently never made it into the saved walkthrough.

This version makes the decision explicit and visible. Answer steps inserted through `insert_walkthrough_tangents` still appear live in the popup, but they are no longer written to the history record at insertion time. The session tracks them as pending groups, one per asked question. When the user closes the walkthrough and pending questions exist, the popup switches to a review screen listing the questions with a keep/discard checkbox each, plus Keep all and Discard all shortcuts. Kept groups are saved to the record; discarded ones are removed from the session before saving.

Discarding only ever happens through that explicit review. If the session ends any other way (project closing, Esc on the review screen, disposal), all pending tangents are kept, which matches the old behavior. Replayed walkthroughs and sessions without questions never see the review step, and the history file format is unchanged.

## Test plan

- [ ] Show a walkthrough via MCP, ask a question, and confirm the answer steps appear live while the file in `.idea/walkthroughs/` stays unchanged.
- [ ] Close the popup: the review screen lists the asked question; discard it and confirm the saved walkthrough has no tangent steps.
- [ ] Repeat and keep the question; confirm the tangent steps are saved.
- [ ] Ask two questions, keep one and discard the other, and check the saved record contains exactly the kept group.
- [ ] Press Esc on the review screen and confirm all pending answers are kept.
- [ ] Close a walkthrough with no questions asked and confirm no review screen appears.
- [ ] Replay a walkthrough from history and confirm it behaves as before.
