### PR TITLE
chore: prepare release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-09-07
+
 ### Added
 
 - `show_walkthrough_items` and `show_diff_walkthrough_items` accept an optional `historyId`

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ org.gradle.configuration-cache=true
 # Enable Gradle Build Cache -> https://docs.gradle.org/current/userguide/build_cache.html
 org.gradle.caching=true
 kotlin.stdlib.default.dependency=false
-pluginVersion=0.5.0
+pluginVersion=0.6.0


### PR DESCRIPTION
## Issue

Prepare the next plugin release from the current `main` branch, including the history update capability from #54 and the empty-items validation fix.

## Solution

Set `pluginVersion` to `0.6.0` and move the existing unreleased changelog entries into the dated release section. This commit changes release metadata only.

## Context

Based on `main` at `2e1ce7330cd1b82c480acdf35efd94e88f558a63`, which merged #54 for #49. The other open feature PRs remain under review.
