### PR TITLE
feat(popup): use IDEA styling and refine connector arrows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- The walkthrough popup now uses IDEA styling by default, including the active appearance theme's
+  colors, typography, native controls, and rounded corners; the animated background is disabled for
+  this style.
+- The walkthrough connector is thinner and now meets the arrowhead at its base for a cleaner arrow.
+
 ## [0.6.0] - 2026-09-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - The walkthrough popup now uses IDEA styling by default, including the active appearance theme's
   colors, typography, native controls, and rounded corners; the animated background is disabled for
-  this style.
+  this style. (PR #79)
 - The walkthrough connector is thinner and now meets the arrowhead at its base for a cleaner arrow.
+  (PR #79)
 
 ## [0.6.0] - 2026-09-07
 

--- a/src/main/kotlin/com/forketyfork/walkthrough/MarkdownRenderer.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/MarkdownRenderer.kt
@@ -45,18 +45,17 @@ import org.jetbrains.jewel.markdown.rendering.InlinesStyling
 import org.jetbrains.jewel.markdown.rendering.MarkdownBlockRenderer
 import org.jetbrains.jewel.markdown.rendering.MarkdownStyling
 
-private val PopupMarkdownTextColor = WalkthroughColors.textPrimary
-private val PopupMarkdownCodeTextColor = WalkthroughColors.textCode
-private val PopupMarkdownInlineCodeBackground = WalkthroughColors.pink.copy(alpha = 0.2f)
-private val PopupMarkdownLinkColor = WalkthroughColors.blue
-private val PopupMarkdownBlockBackground = WalkthroughColors.blockBackground
-private val PopupMarkdownDividerColor = WalkthroughColors.divider
-
 @Composable
-internal fun MarkdownContent(project: Project, markdown: String, modifier: Modifier = Modifier) {
-    val baseTextStyle = rememberPopupBaseTextStyle()
-    val editorTextStyle = rememberPopupEditorTextStyle()
-    val markdownStyling = rememberPopupMarkdownStyling(baseTextStyle, editorTextStyle)
+internal fun MarkdownContent(
+    project: Project,
+    markdown: String,
+    palette: WalkthroughPalette,
+    modifier: Modifier = Modifier,
+) {
+    val popupColors = palette.popupColors()
+    val baseTextStyle = rememberPopupBaseTextStyle(popupColors)
+    val editorTextStyle = rememberPopupEditorTextStyle(popupColors)
+    val markdownStyling = rememberPopupMarkdownStyling(baseTextStyle, editorTextStyle, popupColors)
     val processor = rememberPopupMarkdownProcessor()
     val blockRenderer = rememberPopupMarkdownBlockRenderer(markdownStyling)
     val codeHighlighter = rememberPopupCodeHighlighter(project)
@@ -80,28 +79,37 @@ internal fun MarkdownContent(project: Project, markdown: String, modifier: Modif
 }
 
 @Composable
-private fun rememberPopupBaseTextStyle(): TextStyle = remember(JewelTheme.instanceUuid) {
+private fun rememberPopupBaseTextStyle(colors: WalkthroughPopupColors): TextStyle = remember(
+    JewelTheme.instanceUuid,
+    colors,
+) {
     retrieveDefaultTextStyle().copy(
-        color = PopupMarkdownTextColor,
+        color = colors.contentColor,
         fontSize = 15.sp,
         lineHeight = 22.sp,
     )
 }
 
 @Composable
-private fun rememberPopupEditorTextStyle(): TextStyle = remember(JewelTheme.instanceUuid) {
+private fun rememberPopupEditorTextStyle(colors: WalkthroughPopupColors): TextStyle = remember(
+    JewelTheme.instanceUuid,
+    colors,
+) {
     retrieveEditorTextStyle().copy(
-        color = PopupMarkdownCodeTextColor,
+        color = colors.markdownCodeTextColor,
         fontSize = 13.sp,
         lineHeight = 20.sp,
     )
 }
 
 @Composable
-private fun rememberPopupMarkdownStyling(baseTextStyle: TextStyle, editorTextStyle: TextStyle): MarkdownStyling =
-    remember(JewelTheme.instanceUuid) {
-        createPopupMarkdownStyling(baseTextStyle, editorTextStyle)
-    }
+private fun rememberPopupMarkdownStyling(
+    baseTextStyle: TextStyle,
+    editorTextStyle: TextStyle,
+    colors: WalkthroughPopupColors,
+): MarkdownStyling = remember(JewelTheme.instanceUuid, colors) {
+    createPopupMarkdownStyling(baseTextStyle, editorTextStyle, colors)
+}
 
 @Composable
 private fun rememberPopupMarkdownProcessor(): MarkdownProcessor = remember {
@@ -142,18 +150,22 @@ private fun rememberPopupCodeHighlighter(project: Project) =
         project.service<CodeHighlighterFactory>().createHighlighter()
     }
 
-private fun createPopupMarkdownStyling(baseTextStyle: TextStyle, editorTextStyle: TextStyle): MarkdownStyling {
-    val inlinesStyling = createPopupInlinesStyling(baseTextStyle, editorTextStyle)
+private fun createPopupMarkdownStyling(
+    baseTextStyle: TextStyle,
+    editorTextStyle: TextStyle,
+    colors: WalkthroughPopupColors,
+): MarkdownStyling {
+    val inlinesStyling = createPopupInlinesStyling(baseTextStyle, editorTextStyle, colors)
     return MarkdownStyling.create(
         baseTextStyle = baseTextStyle,
         editorTextStyle = editorTextStyle,
         inlinesStyling = inlinesStyling,
         blockVerticalSpacing = 10.dp,
         paragraph = MarkdownStyling.Paragraph.create(inlinesStyling),
-        heading = createPopupHeadingStyling(baseTextStyle, editorTextStyle),
+        heading = createPopupHeadingStyling(baseTextStyle, editorTextStyle, colors),
         blockQuote = MarkdownStyling.BlockQuote.create(
-            textColor = PopupMarkdownTextColor.copy(alpha = 0.88f),
-            lineColor = PopupMarkdownLinkColor.copy(alpha = 0.45f),
+            textColor = colors.contentColor.copy(alpha = 0.88f),
+            lineColor = colors.markdownLinkColor.copy(alpha = 0.45f),
         ),
         code = MarkdownStyling.Code.create(
             editorTextStyle = editorTextStyle,
@@ -161,15 +173,15 @@ private fun createPopupMarkdownStyling(baseTextStyle: TextStyle, editorTextStyle
                 textStyle = editorTextStyle,
                 padding = PaddingValues(12.dp),
                 shape = RoundedCornerShape(12.dp),
-                background = PopupMarkdownBlockBackground,
+                background = colors.markdownBlockBackground,
             ),
             fenced = MarkdownStyling.Code.Fenced.create(
                 textStyle = editorTextStyle,
                 padding = PaddingValues(12.dp),
                 shape = RoundedCornerShape(12.dp),
-                background = PopupMarkdownBlockBackground,
+                background = colors.markdownBlockBackground,
                 infoTextStyle = editorTextStyle.copy(
-                    color = PopupMarkdownLinkColor,
+                    color = colors.markdownLinkColor,
                     fontSize = 12.sp,
                 ),
             ),
@@ -189,19 +201,23 @@ private fun createPopupMarkdownStyling(baseTextStyle: TextStyle, editorTextStyle
         ),
         thematicBreak = MarkdownStyling.ThematicBreak.create(
             lineWidth = 1.dp,
-            lineColor = PopupMarkdownDividerColor,
+            lineColor = colors.markdownDividerColor,
         ),
         htmlBlock = MarkdownStyling.HtmlBlock.create(
             textStyle = editorTextStyle,
             padding = PaddingValues(12.dp),
             shape = RoundedCornerShape(12.dp),
-            background = PopupMarkdownBlockBackground,
-            borderColor = PopupMarkdownDividerColor,
+            background = colors.markdownBlockBackground,
+            borderColor = colors.markdownDividerColor,
         ),
     )
 }
 
-private fun createPopupHeadingStyling(baseTextStyle: TextStyle, editorTextStyle: TextStyle): MarkdownStyling.Heading {
+private fun createPopupHeadingStyling(
+    baseTextStyle: TextStyle,
+    editorTextStyle: TextStyle,
+    colors: WalkthroughPopupColors,
+): MarkdownStyling.Heading {
     val headerPadding = PaddingValues(top = 12.dp)
     val h1 = baseTextStyle.copy(fontSize = 22.sp, lineHeight = 30.sp, fontWeight = FontWeight.Bold)
     val h2 = baseTextStyle.copy(fontSize = 19.sp, lineHeight = 27.sp, fontWeight = FontWeight.Bold)
@@ -213,42 +229,42 @@ private fun createPopupHeadingStyling(baseTextStyle: TextStyle, editorTextStyle:
         baseTextStyle = baseTextStyle,
         h1 = MarkdownStyling.Heading.H1.create(
             baseTextStyle = h1,
-            inlinesStyling = createPopupInlinesStyling(h1, editorTextStyle),
+            inlinesStyling = createPopupInlinesStyling(h1, editorTextStyle, colors),
             underlineWidth = 0.dp,
             underlineGap = 0.dp,
             padding = headerPadding,
         ),
         h2 = MarkdownStyling.Heading.H2.create(
             baseTextStyle = h2,
-            inlinesStyling = createPopupInlinesStyling(h2, editorTextStyle),
+            inlinesStyling = createPopupInlinesStyling(h2, editorTextStyle, colors),
             underlineWidth = 0.dp,
             underlineGap = 0.dp,
             padding = headerPadding,
         ),
         h3 = MarkdownStyling.Heading.H3.create(
             baseTextStyle = h3,
-            inlinesStyling = createPopupInlinesStyling(h3, editorTextStyle),
+            inlinesStyling = createPopupInlinesStyling(h3, editorTextStyle, colors),
             underlineWidth = 0.dp,
             underlineGap = 0.dp,
             padding = headerPadding,
         ),
         h4 = MarkdownStyling.Heading.H4.create(
             baseTextStyle = h4,
-            inlinesStyling = createPopupInlinesStyling(h4, editorTextStyle),
+            inlinesStyling = createPopupInlinesStyling(h4, editorTextStyle, colors),
             underlineWidth = 0.dp,
             underlineGap = 0.dp,
             padding = headerPadding,
         ),
         h5 = MarkdownStyling.Heading.H5.create(
             baseTextStyle = h5,
-            inlinesStyling = createPopupInlinesStyling(h5, editorTextStyle),
+            inlinesStyling = createPopupInlinesStyling(h5, editorTextStyle, colors),
             underlineWidth = 0.dp,
             underlineGap = 0.dp,
             padding = headerPadding,
         ),
         h6 = MarkdownStyling.Heading.H6.create(
             baseTextStyle = h6,
-            inlinesStyling = createPopupInlinesStyling(h6, editorTextStyle),
+            inlinesStyling = createPopupInlinesStyling(h6, editorTextStyle, colors),
             underlineWidth = 0.dp,
             underlineGap = 0.dp,
             padding = headerPadding,
@@ -256,28 +272,31 @@ private fun createPopupHeadingStyling(baseTextStyle: TextStyle, editorTextStyle:
     )
 }
 
-private fun createPopupInlinesStyling(textStyle: TextStyle, editorTextStyle: TextStyle): InlinesStyling =
-    InlinesStyling.create(
-        textStyle = textStyle,
-        editorTextStyle = editorTextStyle,
-        inlineCode = editorTextStyle.copy(
-            color = PopupMarkdownTextColor,
-            fontSize = textStyle.fontSize * 0.92f,
-            background = PopupMarkdownInlineCodeBackground,
-        ).toSpanStyle(),
-        link = SpanStyle(color = PopupMarkdownLinkColor),
-        linkDisabled = SpanStyle(color = PopupMarkdownLinkColor.copy(alpha = 0.5f)),
-        linkHovered = SpanStyle(
-            color = PopupMarkdownLinkColor,
-            textDecoration = TextDecoration.Underline,
-        ),
-        linkFocused = SpanStyle(
-            color = PopupMarkdownLinkColor,
-            textDecoration = TextDecoration.Underline,
-        ),
-        linkPressed = SpanStyle(
-            color = PopupMarkdownLinkColor.copy(alpha = 0.8f),
-            textDecoration = TextDecoration.Underline,
-        ),
-        linkVisited = SpanStyle(color = PopupMarkdownLinkColor.copy(alpha = 0.85f)),
-    )
+private fun createPopupInlinesStyling(
+    textStyle: TextStyle,
+    editorTextStyle: TextStyle,
+    colors: WalkthroughPopupColors,
+): InlinesStyling = InlinesStyling.create(
+    textStyle = textStyle,
+    editorTextStyle = editorTextStyle,
+    inlineCode = editorTextStyle.copy(
+        color = colors.contentColor,
+        fontSize = textStyle.fontSize * 0.92f,
+        background = colors.markdownInlineCodeBackground,
+    ).toSpanStyle(),
+    link = SpanStyle(color = colors.markdownLinkColor),
+    linkDisabled = SpanStyle(color = colors.markdownLinkColor.copy(alpha = 0.5f)),
+    linkHovered = SpanStyle(
+        color = colors.markdownLinkColor,
+        textDecoration = TextDecoration.Underline,
+    ),
+    linkFocused = SpanStyle(
+        color = colors.markdownLinkColor,
+        textDecoration = TextDecoration.Underline,
+    ),
+    linkPressed = SpanStyle(
+        color = colors.markdownLinkColor.copy(alpha = 0.8f),
+        textDecoration = TextDecoration.Underline,
+    ),
+    linkVisited = SpanStyle(color = colors.markdownLinkColor.copy(alpha = 0.85f)),
+)

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPalette.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPalette.kt
@@ -1,6 +1,7 @@
 package com.forketyfork.walkthrough
 
 import androidx.compose.ui.graphics.Color
+import com.intellij.ui.JBColor
 import java.awt.Color as AwtColor
 
 internal data class WalkthroughPalette(
@@ -18,11 +19,30 @@ internal data class WalkthroughPalette(
     val navPrimaryBorderColor: Color,
     val connectorStrokeColor: AwtColor,
     val connectorArrowFillColor: AwtColor,
+    val isThemeBased: Boolean = false,
 ) {
     val swatchGradientColors: List<Color> = borderGradientColors
 }
 
 internal object WalkthroughPalettes {
+    val IDEA = WalkthroughPalette(
+        id = "idea",
+        displayName = "IDEA",
+        backgroundGradientColors = listOf(Color.Transparent),
+        glowGradientColors = listOf(Color.Transparent, Color.Transparent),
+        overlayColor = Color.Transparent,
+        borderGradientColors = listOf(Color.Transparent),
+        scrollbarUnhoverColor = Color.Transparent,
+        scrollbarHoverColor = Color.Transparent,
+        metaTextColor = Color.Transparent,
+        badgeGradientColors = listOf(Color.Transparent),
+        navPrimaryGradientColors = listOf(Color.Transparent),
+        navPrimaryBorderColor = Color.Transparent,
+        connectorStrokeColor = JBColor.namedColor("Component.focusColor", AwtColor(76, 131, 230)),
+        connectorArrowFillColor = JBColor.namedColor("Component.focusColor", AwtColor(76, 131, 230)),
+        isThemeBased = true,
+    )
+
     val PURPLE = WalkthroughPalette(
         id = "purple",
         displayName = "Purple",
@@ -146,8 +166,8 @@ internal object WalkthroughPalettes {
         connectorArrow = AwtColor(236, 72, 153, 215),
     )
 
-    val all: List<WalkthroughPalette> = listOf(PURPLE, GREEN, BLUE, RED, ORANGE, TEAL, PINK)
-    val default: WalkthroughPalette = PURPLE
+    val all: List<WalkthroughPalette> = listOf(IDEA, PURPLE, GREEN, BLUE, RED, ORANGE, TEAL, PINK)
+    val default: WalkthroughPalette = IDEA
 
     private val byId = all.associateBy(WalkthroughPalette::id)
 

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupContent.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupContent.kt
@@ -43,11 +43,11 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.intellij.openapi.project.Project
 import kotlinx.coroutines.delay
+import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.ui.component.Text
 import kotlin.time.TimeSource
 
 private object WalkthroughPopupContentStyle {
-    val cornerRadius = 24.dp
     val textMinHeight = 180.dp
     val scrollbarMinHeight = 28.dp
     val scrollbarThickness = 6.dp
@@ -79,14 +79,12 @@ private object WalkthroughPopupContentStyle {
     val contentPaddingBottom = 16.dp
     val contentSectionSpacing = 14.dp
     val headerSpacing = 10.dp
-    val headerPillRadius = 999.dp
     const val HEADER_BACKGROUND_ALPHA = 0.06f
     val headerBorderWidth = 1.dp
     const val HEADER_BORDER_ALPHA = 0.08f
     val headerPaddingHorizontal = 8.dp
     val headerPaddingVertical = 6.dp
     val metaTextSize = 12.sp
-    val bodyCornerRadius = 18.dp
     const val BODY_BACKGROUND_ALPHA = 0.08f
     val bodyBorderWidth = 1.dp
     const val BODY_BORDER_ALPHA = 0.12f
@@ -116,8 +114,9 @@ internal fun WalkthroughItemContent(
     val safeIndex = currentIndex.coerceIn(0, (items.size - 1).coerceAtLeast(0))
     val item = items.getOrNull(safeIndex) ?: return
     val scrollState = rememberScrollState()
-    val animationState = rememberPopupAnimationState()
-    val scrollbarStyle = rememberPopupScrollbarStyle(palette)
+    val popupColors = palette.popupColors()
+    val animationState = rememberPopupAnimationState(palette)
+    val scrollbarStyle = rememberPopupScrollbarStyle(popupColors)
     val showScrollbar = scrollState.maxValue > 0
     val questionStatus by session.questionStatusState
 
@@ -144,6 +143,7 @@ internal fun WalkthroughItemContent(
             acceptsQuestions = session.acceptsQuestions,
             questionStatus = questionStatus,
             palette = palette,
+            popupColors = popupColors,
             scrollState = scrollState,
             showScrollbar = showScrollbar,
             animationState = animationState,
@@ -157,8 +157,8 @@ internal fun WalkthroughItemContent(
 }
 
 @Composable
-private fun rememberPopupAnimationState(): WalkthroughPopupAnimationState {
-    if (WalkthroughDebugOptions.disablePopupContentAnimation) {
+private fun rememberPopupAnimationState(palette: WalkthroughPalette): WalkthroughPopupAnimationState {
+    if (palette.isThemeBased || WalkthroughDebugOptions.disablePopupContentAnimation) {
         return remember {
             WalkthroughPopupAnimationState(
                 gradientShift = WalkthroughPopupContentStyle.ANIMATION_START,
@@ -181,18 +181,18 @@ private fun rememberPopupAnimationState(): WalkthroughPopupAnimationState {
 }
 
 @Composable
-private fun rememberPopupScrollbarStyle(palette: WalkthroughPalette): ScrollbarStyle = remember(palette) {
+private fun rememberPopupScrollbarStyle(colors: WalkthroughPopupColors): ScrollbarStyle = remember(colors) {
     ScrollbarStyle(
         minimalHeight = WalkthroughPopupContentStyle.scrollbarMinHeight,
         thickness = WalkthroughPopupContentStyle.scrollbarThickness,
         shape = CircleShape,
         hoverDurationMillis = WalkthroughPopupContentStyle.SCROLLBAR_HOVER_DURATION_MS,
-        unhoverColor = palette.scrollbarUnhoverColor,
-        hoverColor = palette.scrollbarHoverColor,
+        unhoverColor = colors.scrollbarUnhoverColor,
+        hoverColor = colors.scrollbarHoverColor,
     )
 }
 
-@Suppress("LongParameterList")
+@Suppress("LongParameterList", "LongMethod")
 @Composable
 private fun WalkthroughPopupFrame(
     project: Project,
@@ -202,6 +202,7 @@ private fun WalkthroughPopupFrame(
     acceptsQuestions: Boolean,
     questionStatus: WalkthroughQuestionStatus,
     palette: WalkthroughPalette,
+    popupColors: WalkthroughPopupColors,
     scrollState: ScrollState,
     showScrollbar: Boolean,
     animationState: WalkthroughPopupAnimationState,
@@ -211,14 +212,15 @@ private fun WalkthroughPopupFrame(
     onSubmitQuestion: (String) -> Unit,
     onClose: () -> Unit,
 ) {
-    val shape = RoundedCornerShape(WalkthroughPopupContentStyle.cornerRadius)
+    val shape = RoundedCornerShape(palette.popupCornerRadius())
     Box(
         modifier = Modifier
             .fillMaxSize()
             .clip(shape)
-            .walkthroughPopupBackground(animationState, palette),
+            .walkthroughPopupBackground(animationState, palette, popupColors),
     ) {
         AiCloseButton(
+            palette = palette,
             modifier = Modifier
                 .align(Alignment.TopEnd)
                 .padding(WalkthroughPopupContentStyle.closeButtonPadding),
@@ -235,10 +237,18 @@ private fun WalkthroughPopupFrame(
                 ),
             verticalArrangement = Arrangement.spacedBy(WalkthroughPopupContentStyle.contentSectionSpacing),
         ) {
-            WalkthroughPopupHeader(item = item, items = items, currentIndex = currentIndex, palette = palette)
+            WalkthroughPopupHeader(
+                item = item,
+                items = items,
+                currentIndex = currentIndex,
+                palette = palette,
+                popupColors = popupColors,
+            )
             WalkthroughPopupBody(
                 project = project,
                 item = item,
+                palette = palette,
+                popupColors = popupColors,
                 scrollState = scrollState,
                 showScrollbar = showScrollbar,
             )
@@ -259,6 +269,7 @@ private fun WalkthroughPopupFrame(
                 WalkthroughQuestionInput(
                     status = questionStatus,
                     palette = palette,
+                    popupColors = popupColors,
                     onSubmit = onSubmitQuestion,
                 )
             }
@@ -269,16 +280,22 @@ private fun WalkthroughPopupFrame(
 private fun WalkthroughItem.hasNavigationTarget(): Boolean =
     file != null || line != null || diffId != null || diffFile != null
 
+@Suppress("LongMethod")
 private fun Modifier.walkthroughPopupBackground(
     animationState: WalkthroughPopupAnimationState,
     palette: WalkthroughPalette,
+    popupColors: WalkthroughPopupColors,
 ): Modifier = drawWithCache {
     val cornerRadius = CornerRadius(
-        WalkthroughPopupContentStyle.cornerRadius.toPx(),
-        WalkthroughPopupContentStyle.cornerRadius.toPx(),
+        palette.popupCornerRadius().toPx(),
+        palette.popupCornerRadius().toPx(),
     )
     val backgroundBrush = Brush.linearGradient(
-        colors = palette.backgroundGradientColors,
+        colors = if (palette.isThemeBased) {
+            listOf(popupColors.backgroundColor, popupColors.backgroundColor)
+        } else {
+            palette.backgroundGradientColors
+        },
         start = Offset(
             size.width * (animationState.gradientShift - WalkthroughPopupContentStyle.BACKGROUND_START_X_SHIFT),
             -size.height * WalkthroughPopupContentStyle.BACKGROUND_START_Y_SHIFT,
@@ -289,7 +306,11 @@ private fun Modifier.walkthroughPopupBackground(
         ),
     )
     val glowBrush = Brush.radialGradient(
-        colors = palette.glowGradientColors,
+        colors = if (palette.isThemeBased) {
+            listOf(Color.Transparent, Color.Transparent)
+        } else {
+            palette.glowGradientColors
+        },
         center = Offset(
             size.width * (
                 WalkthroughPopupContentStyle.GLOW_CENTER_BASE_X +
@@ -300,7 +321,11 @@ private fun Modifier.walkthroughPopupBackground(
         radius = size.minDimension * WalkthroughPopupContentStyle.GLOW_RADIUS_FACTOR,
     )
     val borderBrush = Brush.linearGradient(
-        colors = palette.borderGradientColors,
+        colors = if (palette.isThemeBased) {
+            listOf(popupColors.borderColor, popupColors.borderColor)
+        } else {
+            palette.borderGradientColors
+        },
         start = Offset(
             size.width * (animationState.gradientShift - WalkthroughPopupContentStyle.BORDER_GRADIENT_START_SHIFT),
             0f,
@@ -310,12 +335,14 @@ private fun Modifier.walkthroughPopupBackground(
 
     onDrawBehind {
         drawRoundRect(brush = backgroundBrush, cornerRadius = cornerRadius)
-        drawRoundRect(brush = glowBrush, cornerRadius = cornerRadius)
-        drawRoundRect(color = palette.overlayColor, cornerRadius = cornerRadius)
+        if (!palette.isThemeBased) {
+            drawRoundRect(brush = glowBrush, cornerRadius = cornerRadius)
+            drawRoundRect(color = palette.overlayColor, cornerRadius = cornerRadius)
+        }
         drawRoundRect(
             brush = borderBrush,
             cornerRadius = cornerRadius,
-            alpha = WalkthroughPopupContentStyle.BORDER_ALPHA,
+            alpha = if (palette.isThemeBased) 1f else WalkthroughPopupContentStyle.BORDER_ALPHA,
             style = Stroke(width = WalkthroughPopupContentStyle.borderStrokeWidth.toPx()),
         )
     }
@@ -327,18 +354,29 @@ private fun WalkthroughPopupHeader(
     items: List<WalkthroughItem>,
     currentIndex: Int,
     palette: WalkthroughPalette,
+    popupColors: WalkthroughPopupColors,
 ) {
     Row(
         horizontalArrangement = Arrangement.spacedBy(WalkthroughPopupContentStyle.headerSpacing),
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier
             .wrapContentWidth()
-            .clip(RoundedCornerShape(WalkthroughPopupContentStyle.headerPillRadius))
-            .background(Color.White.copy(alpha = WalkthroughPopupContentStyle.HEADER_BACKGROUND_ALPHA))
+            .clip(RoundedCornerShape(palette.headerCornerRadius()))
+            .background(
+                if (palette.isThemeBased) {
+                    popupColors.fieldBackgroundColor
+                } else {
+                    Color.White.copy(alpha = WalkthroughPopupContentStyle.HEADER_BACKGROUND_ALPHA)
+                },
+            )
             .border(
                 width = WalkthroughPopupContentStyle.headerBorderWidth,
-                color = Color.White.copy(alpha = WalkthroughPopupContentStyle.HEADER_BORDER_ALPHA),
-                shape = RoundedCornerShape(WalkthroughPopupContentStyle.headerPillRadius),
+                color = if (palette.isThemeBased) {
+                    popupColors.borderColor
+                } else {
+                    Color.White.copy(alpha = WalkthroughPopupContentStyle.HEADER_BORDER_ALPHA)
+                },
+                shape = RoundedCornerShape(palette.headerCornerRadius()),
             )
             .padding(
                 horizontal = WalkthroughPopupContentStyle.headerPaddingHorizontal,
@@ -350,9 +388,11 @@ private fun WalkthroughPopupHeader(
         if (meta != null) {
             Text(
                 text = meta,
-                color = palette.metaTextColor,
-                fontSize = WalkthroughPopupContentStyle.metaTextSize,
-                fontWeight = FontWeight.Medium,
+                color = popupColors.metaTextColor,
+                style = JewelTheme.defaultTextStyle.copy(
+                    fontSize = WalkthroughPopupContentStyle.metaTextSize,
+                    fontWeight = FontWeight.Medium,
+                ),
             )
         }
     }
@@ -372,9 +412,12 @@ private fun headerMetaText(item: WalkthroughItem, items: List<WalkthroughItem>, 
 }
 
 @Composable
+@Suppress("LongParameterList")
 private fun ColumnScope.WalkthroughPopupBody(
     project: Project,
     item: WalkthroughItem,
+    palette: WalkthroughPalette,
+    popupColors: WalkthroughPopupColors,
     scrollState: ScrollState,
     showScrollbar: Boolean,
 ) {
@@ -383,12 +426,22 @@ private fun ColumnScope.WalkthroughPopupBody(
             .fillMaxWidth()
             .weight(1f, fill = true)
             .heightIn(min = WalkthroughPopupContentStyle.textMinHeight)
-            .clip(RoundedCornerShape(WalkthroughPopupContentStyle.bodyCornerRadius))
-            .background(Color.White.copy(alpha = WalkthroughPopupContentStyle.BODY_BACKGROUND_ALPHA))
+            .clip(RoundedCornerShape(palette.bodyCornerRadius()))
+            .background(
+                if (palette.isThemeBased) {
+                    popupColors.fieldBackgroundColor
+                } else {
+                    Color.White.copy(alpha = WalkthroughPopupContentStyle.BODY_BACKGROUND_ALPHA)
+                },
+            )
             .border(
                 width = WalkthroughPopupContentStyle.bodyBorderWidth,
-                color = Color.White.copy(alpha = WalkthroughPopupContentStyle.BODY_BORDER_ALPHA),
-                shape = RoundedCornerShape(WalkthroughPopupContentStyle.bodyCornerRadius),
+                color = if (palette.isThemeBased) {
+                    popupColors.borderColor
+                } else {
+                    Color.White.copy(alpha = WalkthroughPopupContentStyle.BODY_BORDER_ALPHA)
+                },
+                shape = RoundedCornerShape(palette.bodyCornerRadius()),
             ),
     ) {
         Box(
@@ -402,7 +455,7 @@ private fun ColumnScope.WalkthroughPopupBody(
                 )
                 .verticalScroll(scrollState),
         ) {
-            MarkdownContent(project, item.text)
+            MarkdownContent(project, item.text, palette)
         }
 
         if (showScrollbar) {

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupSurface.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupSurface.kt
@@ -41,7 +41,7 @@ internal object WalkthroughConnectorStyle {
     const val DEFAULT_SIGN = 1f
     const val ARROW_SPREAD_DEGREES = 24.0
     const val ARROW_HEAD_LENGTH = 13.0
-    const val STROKE_WIDTH = 3.5f
+    const val STROKE_WIDTH = 2.45f
 }
 
 private data class ConnectorPaintContext(
@@ -343,16 +343,25 @@ private fun buildConnector(anchor: ConnectorAnchor, end: Point2D.Float): Connect
     }
     val path = Path2D.Float().apply {
         moveTo(anchor.point.x.toDouble(), anchor.point.y.toDouble())
+        val lineEnd = connectorLineEnd(end, endControl)
         curveTo(
             startControl.x.toDouble(),
             startControl.y.toDouble(),
             endControl.x.toDouble(),
             endControl.y.toDouble(),
-            end.x.toDouble(),
-            end.y.toDouble(),
+            lineEnd.x.toDouble(),
+            lineEnd.y.toDouble(),
         )
     }
     return ConnectorPath(path, end, endControl)
+}
+
+internal fun connectorLineEnd(end: Point2D.Float, endControl: Point2D.Float): Point2D.Float {
+    val angle = atan2((end.y - endControl.y).toDouble(), (end.x - endControl.x).toDouble())
+    return Point2D.Float(
+        end.x - (WalkthroughConnectorStyle.ARROW_HEAD_LENGTH * cos(angle)).toFloat(),
+        end.y - (WalkthroughConnectorStyle.ARROW_HEAD_LENGTH * sin(angle)).toFloat(),
+    )
 }
 
 private fun drawArrowHead(

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupTheme.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupTheme.kt
@@ -1,0 +1,88 @@
+@file:OptIn(ExperimentalJewelApi::class)
+@file:Suppress("MatchingDeclarationName")
+
+package com.forketyfork.walkthrough
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import org.jetbrains.jewel.foundation.ExperimentalJewelApi
+import org.jetbrains.jewel.foundation.theme.JewelTheme
+
+internal data class WalkthroughPopupColors(
+    val backgroundColor: Color,
+    val borderColor: Color,
+    val contentColor: Color,
+    val disabledContentColor: Color,
+    val accentColor: Color,
+    val fieldBackgroundColor: Color,
+    val fieldBorderColor: Color,
+    val scrollbarUnhoverColor: Color,
+    val scrollbarHoverColor: Color,
+    val metaTextColor: Color,
+    val markdownCodeTextColor: Color,
+    val markdownInlineCodeBackground: Color,
+    val markdownLinkColor: Color,
+    val markdownBlockBackground: Color,
+    val markdownDividerColor: Color,
+)
+
+@Composable
+internal fun WalkthroughPalette.popupColors(): WalkthroughPopupColors {
+    if (!isThemeBased) {
+        return WalkthroughPopupColors(
+            backgroundColor = paletteBackgroundColor(),
+            borderColor = borderGradientColors.first(),
+            contentColor = WalkthroughColors.textPrimary,
+            disabledContentColor = Color.White.copy(alpha = 0.45f),
+            accentColor = navPrimaryBorderColor,
+            fieldBackgroundColor = Color.White.copy(alpha = 0.12f),
+            fieldBorderColor = Color.White.copy(alpha = 0.2f),
+            scrollbarUnhoverColor = scrollbarUnhoverColor,
+            scrollbarHoverColor = scrollbarHoverColor,
+            metaTextColor = metaTextColor,
+            markdownCodeTextColor = WalkthroughColors.textCode,
+            markdownInlineCodeBackground = WalkthroughColors.pink.copy(alpha = 0.2f),
+            markdownLinkColor = WalkthroughColors.blue,
+            markdownBlockBackground = WalkthroughColors.blockBackground,
+            markdownDividerColor = WalkthroughColors.divider,
+        )
+    }
+
+    val globalColors = JewelTheme.globalColors
+    val contentColor = JewelTheme.contentColor
+    val borderColor = globalColors.borders.normal
+    val accentColor = globalColors.borders.focused
+    val panelBackground = globalColors.panelBackground
+    val fieldBackground = globalColors.toolwindowBackground
+    val disabledContentColor = globalColors.text.disabled
+    val infoColor = globalColors.text.info
+
+    return WalkthroughPopupColors(
+        backgroundColor = panelBackground,
+        borderColor = borderColor,
+        contentColor = contentColor,
+        disabledContentColor = disabledContentColor,
+        accentColor = accentColor,
+        fieldBackgroundColor = fieldBackground,
+        fieldBorderColor = borderColor,
+        scrollbarUnhoverColor = borderColor,
+        scrollbarHoverColor = accentColor,
+        metaTextColor = globalColors.text.normal,
+        markdownCodeTextColor = contentColor,
+        markdownInlineCodeBackground = infoColor.copy(alpha = 0.16f),
+        markdownLinkColor = infoColor,
+        markdownBlockBackground = fieldBackground,
+        markdownDividerColor = borderColor,
+    )
+}
+
+internal fun WalkthroughPalette.popupCornerRadius() = if (isThemeBased) 8.dp else 24.dp
+
+internal fun WalkthroughPalette.headerCornerRadius() = if (isThemeBased) 6.dp else 999.dp
+
+internal fun WalkthroughPalette.bodyCornerRadius() = if (isThemeBased) 6.dp else 18.dp
+
+internal fun WalkthroughPalette.questionFieldCornerRadius() = if (isThemeBased) 6.dp else 18.dp
+
+private fun WalkthroughPalette.paletteBackgroundColor(): Color = backgroundGradientColors.first()

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupWidgets.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupWidgets.kt
@@ -45,7 +45,11 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import org.jetbrains.jewel.foundation.theme.JewelTheme
+import org.jetbrains.jewel.ui.component.DefaultButton
 import org.jetbrains.jewel.ui.component.Icon
+import org.jetbrains.jewel.ui.component.IconButton
+import org.jetbrains.jewel.ui.component.OutlinedButton
 import org.jetbrains.jewel.ui.component.Text
 import org.jetbrains.jewel.ui.icons.AllIconsKeys
 
@@ -68,7 +72,6 @@ private object WalkthroughWidgetStyle {
     val navVerticalPadding = 8.dp
     val navTextSize = 13.sp
     val questionRowSpacing = 8.dp
-    val questionFieldRadius = 18.dp
     val questionFieldPaddingHorizontal = 14.dp
     val questionFieldTextSize = 13.sp
     val questionStatusSpacing = 4.dp
@@ -118,17 +121,29 @@ internal fun WalkthroughPopupNavigation(
             )
         }
         if (onNavigateToSource != null) {
-            GoToSourceButton(onClick = onNavigateToSource)
+            GoToSourceButton(palette = palette, onClick = onNavigateToSource)
         }
     }
 }
 
 @Composable
 internal fun AiBadge(palette: WalkthroughPalette) {
+    val popupColors = palette.popupColors()
     Box(
         modifier = Modifier
-            .clip(CircleShape)
-            .background(brush = Brush.linearGradient(palette.badgeGradientColors))
+            .clip(RoundedCornerShape(palette.headerCornerRadius()))
+            .background(
+                brush = if (palette.isThemeBased) {
+                    Brush.linearGradient(
+                        listOf(
+                            popupColors.accentColor.copy(alpha = 0.16f),
+                            popupColors.accentColor.copy(alpha = 0.16f),
+                        ),
+                    )
+                } else {
+                    Brush.linearGradient(palette.badgeGradientColors)
+                },
+            )
             .padding(
                 horizontal = WalkthroughWidgetStyle.badgePaddingHorizontal,
                 vertical = WalkthroughWidgetStyle.badgePaddingVertical,
@@ -136,15 +151,36 @@ internal fun AiBadge(palette: WalkthroughPalette) {
     ) {
         Text(
             text = "Walkthrough",
-            color = Color.White,
-            fontSize = WalkthroughWidgetStyle.badgeTextSize,
-            fontWeight = FontWeight.SemiBold,
+            color = if (palette.isThemeBased) popupColors.contentColor else Color.White,
+            style = if (palette.isThemeBased) {
+                JewelTheme.defaultTextStyle.copy(
+                    fontSize = WalkthroughWidgetStyle.badgeTextSize,
+                    fontWeight = FontWeight.SemiBold,
+                )
+            } else {
+                TextStyle(
+                    fontSize = WalkthroughWidgetStyle.badgeTextSize,
+                    fontWeight = FontWeight.SemiBold,
+                )
+            },
         )
     }
 }
 
 @Composable
-internal fun AiCloseButton(onClick: () -> Unit, modifier: Modifier = Modifier) {
+internal fun AiCloseButton(palette: WalkthroughPalette, onClick: () -> Unit, modifier: Modifier = Modifier) {
+    if (palette.isThemeBased) {
+        IconButton(
+            onClick = onClick,
+            modifier = modifier.size(WalkthroughWidgetStyle.closeButtonSize),
+        ) {
+            Icon(
+                key = AllIconsKeys.General.Close,
+                contentDescription = "Close walkthrough",
+            )
+        }
+        return
+    }
     Box(
         modifier = modifier
             .size(WalkthroughWidgetStyle.closeButtonSize)
@@ -168,7 +204,19 @@ internal fun AiCloseButton(onClick: () -> Unit, modifier: Modifier = Modifier) {
 }
 
 @Composable
-internal fun GoToSourceButton(onClick: () -> Unit, modifier: Modifier = Modifier) {
+internal fun GoToSourceButton(palette: WalkthroughPalette, onClick: () -> Unit, modifier: Modifier = Modifier) {
+    if (palette.isThemeBased) {
+        IconButton(
+            onClick = onClick,
+            modifier = modifier.size(WalkthroughWidgetStyle.sendButtonSize),
+        ) {
+            Icon(
+                key = AllIconsKeys.General.Locate,
+                contentDescription = "Go to source",
+            )
+        }
+        return
+    }
     Box(
         modifier = modifier
             .size(WalkthroughWidgetStyle.sendButtonSize)
@@ -198,6 +246,18 @@ internal fun AiNavButton(
     palette: WalkthroughPalette,
     onClick: () -> Unit,
 ) {
+    if (palette.isThemeBased) {
+        if (emphasized) {
+            DefaultButton(onClick = onClick, enabled = enabled) {
+                Text(label)
+            }
+        } else {
+            OutlinedButton(onClick = onClick, enabled = enabled) {
+                Text(label)
+            }
+        }
+        return
+    }
     val backgroundBrush = if (emphasized) {
         Brush.linearGradient(palette.navPrimaryGradientColors)
     } else {
@@ -241,6 +301,7 @@ internal fun AiNavButton(
 internal fun WalkthroughQuestionInput(
     status: WalkthroughQuestionStatus,
     palette: WalkthroughPalette,
+    popupColors: WalkthroughPopupColors,
     onSubmit: (String) -> Unit,
 ) {
     var text by remember { mutableStateOf("") }
@@ -266,41 +327,59 @@ internal fun WalkthroughQuestionInput(
                 text = text,
                 enabled = canType,
                 placeholder = questionPlaceholder(status),
+                palette = palette,
+                popupColors = popupColors,
                 onTextChange = { value -> text = value },
                 onSend = submit,
                 modifier = Modifier.weight(1f),
             )
             if (status == WalkthroughQuestionStatus.ProcessingQuestion) {
-                QuestionSpinner(palette = palette)
+                QuestionSpinner(palette = palette, popupColors = popupColors)
             } else {
-                SendQuestionButton(enabled = canSubmit, palette = palette, onClick = submit)
+                SendQuestionButton(
+                    enabled = canSubmit,
+                    palette = palette,
+                    onClick = submit,
+                )
             }
         }
-        QuestionStatusText(status = status)
+        QuestionStatusText(status = status, popupColors = popupColors)
     }
 }
 
 @Composable
+@Suppress("LongParameterList", "LongMethod")
 private fun QuestionTextField(
     text: String,
     enabled: Boolean,
     placeholder: String,
     onTextChange: (String) -> Unit,
     onSend: () -> Unit,
+    palette: WalkthroughPalette,
+    popupColors: WalkthroughPopupColors,
     modifier: Modifier = Modifier,
 ) {
+    val fieldShape = RoundedCornerShape(palette.questionFieldCornerRadius())
     Box(
         modifier = modifier
             .height(WalkthroughWidgetStyle.sendButtonSize)
-            .clip(RoundedCornerShape(WalkthroughWidgetStyle.questionFieldRadius))
+            .clip(fieldShape)
             .background(
-                Color.White.copy(alpha = WalkthroughWidgetStyle.QUESTION_FIELD_BACKGROUND_ALPHA),
-                RoundedCornerShape(WalkthroughWidgetStyle.questionFieldRadius),
+                if (palette.isThemeBased) {
+                    popupColors.fieldBackgroundColor
+                } else {
+                    Color.White.copy(alpha = WalkthroughWidgetStyle.QUESTION_FIELD_BACKGROUND_ALPHA)
+                },
+                fieldShape,
             )
             .border(
                 WalkthroughWidgetStyle.closeButtonBorderWidth,
-                Color.White.copy(alpha = WalkthroughWidgetStyle.QUESTION_FIELD_BORDER_ALPHA),
-                RoundedCornerShape(WalkthroughWidgetStyle.questionFieldRadius),
+                if (palette.isThemeBased) {
+                    popupColors.fieldBorderColor
+                } else {
+                    Color.White.copy(alpha = WalkthroughWidgetStyle.QUESTION_FIELD_BORDER_ALPHA)
+                },
+                fieldShape,
             )
             .padding(horizontal = WalkthroughWidgetStyle.questionFieldPaddingHorizontal),
         contentAlignment = Alignment.CenterStart,
@@ -310,12 +389,20 @@ private fun QuestionTextField(
             onValueChange = onTextChange,
             enabled = enabled,
             singleLine = true,
-            textStyle = TextStyle(
-                color = Color.White,
-                fontSize = WalkthroughWidgetStyle.questionFieldTextSize,
-                fontWeight = FontWeight.Normal,
-            ),
-            cursorBrush = SolidColor(Color.White),
+            textStyle = if (palette.isThemeBased) {
+                JewelTheme.defaultTextStyle.copy(
+                    color = popupColors.contentColor,
+                    fontSize = WalkthroughWidgetStyle.questionFieldTextSize,
+                    fontWeight = FontWeight.Normal,
+                )
+            } else {
+                TextStyle(
+                    color = Color.White,
+                    fontSize = WalkthroughWidgetStyle.questionFieldTextSize,
+                    fontWeight = FontWeight.Normal,
+                )
+            },
+            cursorBrush = SolidColor(if (palette.isThemeBased) popupColors.accentColor else Color.White),
             keyboardOptions = KeyboardOptions(imeAction = ImeAction.Send),
             keyboardActions = KeyboardActions(onSend = { onSend() }),
             modifier = Modifier.fillMaxWidth(),
@@ -323,8 +410,16 @@ private fun QuestionTextField(
                 if (text.isEmpty()) {
                     Text(
                         text = placeholder,
-                        color = Color.White.copy(alpha = WalkthroughWidgetStyle.QUESTION_PLACEHOLDER_ALPHA),
-                        fontSize = WalkthroughWidgetStyle.questionFieldTextSize,
+                        color = if (palette.isThemeBased) {
+                            popupColors.disabledContentColor
+                        } else {
+                            Color.White.copy(alpha = WalkthroughWidgetStyle.QUESTION_PLACEHOLDER_ALPHA)
+                        },
+                        style = if (palette.isThemeBased) {
+                            JewelTheme.defaultTextStyle.copy(fontSize = WalkthroughWidgetStyle.questionFieldTextSize)
+                        } else {
+                            TextStyle(fontSize = WalkthroughWidgetStyle.questionFieldTextSize)
+                        },
                     )
                 }
                 innerTextField()
@@ -334,12 +429,12 @@ private fun QuestionTextField(
 }
 
 @Composable
-private fun QuestionStatusText(status: WalkthroughQuestionStatus) {
+private fun QuestionStatusText(status: WalkthroughQuestionStatus, popupColors: WalkthroughPopupColors) {
     val text = questionStatusText(status) ?: return
     Text(
         text = text,
-        color = Color.White.copy(alpha = WalkthroughWidgetStyle.QUESTION_STATUS_ALPHA),
-        fontSize = WalkthroughWidgetStyle.questionStatusTextSize,
+        color = popupColors.disabledContentColor.copy(alpha = WalkthroughWidgetStyle.QUESTION_STATUS_ALPHA),
+        style = JewelTheme.defaultTextStyle.copy(fontSize = WalkthroughWidgetStyle.questionStatusTextSize),
     )
 }
 
@@ -366,6 +461,19 @@ private fun questionStatusText(status: WalkthroughQuestionStatus): String? = whe
 
 @Composable
 private fun SendQuestionButton(enabled: Boolean, palette: WalkthroughPalette, onClick: () -> Unit) {
+    if (palette.isThemeBased) {
+        IconButton(
+            onClick = onClick,
+            enabled = enabled,
+            modifier = Modifier.size(WalkthroughWidgetStyle.sendButtonSize),
+        ) {
+            Icon(
+                key = AllIconsKeys.Actions.Forward,
+                contentDescription = "Send question",
+            )
+        }
+        return
+    }
     val backgroundBrush = Brush.linearGradient(palette.navPrimaryGradientColors)
     Box(
         modifier = Modifier
@@ -387,7 +495,7 @@ private fun SendQuestionButton(enabled: Boolean, palette: WalkthroughPalette, on
 }
 
 @Composable
-private fun QuestionSpinner(palette: WalkthroughPalette) {
+private fun QuestionSpinner(palette: WalkthroughPalette, popupColors: WalkthroughPopupColors) {
     val transition = rememberInfiniteTransition(label = "walkthrough-question-spinner")
     val rotation by transition.animateFloat(
         initialValue = 0f,
@@ -406,12 +514,12 @@ private fun QuestionSpinner(palette: WalkthroughPalette) {
         contentAlignment = Alignment.Center,
     ) {
         Canvas(modifier = Modifier.size(WalkthroughWidgetStyle.spinnerSize).rotate(rotation)) {
-            drawSpinnerArc(palette = palette)
+            drawSpinnerArc(palette = palette, popupColors = popupColors)
         }
     }
 }
 
-private fun DrawScope.drawSpinnerArc(palette: WalkthroughPalette) {
+private fun DrawScope.drawSpinnerArc(palette: WalkthroughPalette, popupColors: WalkthroughPopupColors) {
     val strokeWidthPx = WalkthroughWidgetStyle.spinnerStrokeWidth.toPx()
     val arcSize = Size(
         size.width - strokeWidthPx,
@@ -428,7 +536,7 @@ private fun DrawScope.drawSpinnerArc(palette: WalkthroughPalette) {
         style = Stroke(width = strokeWidthPx),
     )
     drawArc(
-        color = palette.navPrimaryBorderColor,
+        color = if (palette.isThemeBased) popupColors.accentColor else palette.navPrimaryBorderColor,
         startAngle = 0f,
         sweepAngle = WalkthroughWidgetStyle.SPINNER_SWEEP_DEGREES,
         useCenter = false,

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupWidgets.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughPopupWidgets.kt
@@ -527,7 +527,11 @@ private fun DrawScope.drawSpinnerArc(palette: WalkthroughPalette, popupColors: W
     )
     val topLeft = Offset(strokeWidthPx / 2f, strokeWidthPx / 2f)
     drawArc(
-        color = Color.White.copy(alpha = WalkthroughWidgetStyle.SPINNER_TRACK_ALPHA),
+        color = if (palette.isThemeBased) {
+            popupColors.disabledContentColor.copy(alpha = WalkthroughWidgetStyle.SPINNER_TRACK_ALPHA)
+        } else {
+            Color.White.copy(alpha = WalkthroughWidgetStyle.SPINNER_TRACK_ALPHA)
+        },
         startAngle = 0f,
         sweepAngle = 360f,
         useCenter = false,

--- a/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughSettingsConfigurable.kt
+++ b/src/main/kotlin/com/forketyfork/walkthrough/WalkthroughSettingsConfigurable.kt
@@ -117,14 +117,15 @@ internal class WalkthroughSettingsConfigurable : Configurable {
     }
 }
 
-private fun settingsHeading(): JLabel = JLabel("Walkthrough popup colors").apply {
+private fun settingsHeading(): JLabel = JLabel("Walkthrough popup style").apply {
     font = font.deriveFont(Font.BOLD)
 }
 
-private fun settingsDescription(): JLabel =
-    JLabel("These palettes style the popup background, border, controls, scrollbar, and source connector.").apply {
-        foreground = JBColor.GRAY
-    }
+private fun settingsDescription(): JLabel = JLabel(
+    "IDEA follows the current appearance theme; other palettes customize the popup colors and connector.",
+).apply {
+    foreground = JBColor.GRAY
+}
 
 private fun fullWidthConstraints(gridRow: Int, bottomInset: Int): GridBagConstraints = GridBagConstraints().apply {
     gridx = 0
@@ -223,25 +224,38 @@ private class PaletteSwatch(private val palette: WalkthroughPalette) : JComponen
 
     private fun swatchPaint(): Paint {
         val colors = palette.swatchGradientColors.map { AwtColor(it.toArgb(), true) }
-        if (
+        return when {
+            palette.isThemeBased -> themeSwatchPaint()
+
             colors.size < WalkthroughSettingsStyle.MIN_GRADIENT_COLOR_COUNT ||
-            width < WalkthroughSettingsStyle.MIN_PAINT_SIZE ||
-            height < WalkthroughSettingsStyle.MIN_PAINT_SIZE
-        ) {
-            return colors.firstOrNull() ?: JBColor.GRAY
-        }
+                width < WalkthroughSettingsStyle.MIN_PAINT_SIZE ||
+                height < WalkthroughSettingsStyle.MIN_PAINT_SIZE -> colors.firstOrNull() ?: JBColor.GRAY
 
-        val fractions = FloatArray(colors.size) { index ->
-            index.toFloat() / colors.lastIndex.toFloat()
+            else -> {
+                val fractions = FloatArray(colors.size) { index ->
+                    index.toFloat() / colors.lastIndex.toFloat()
+                }
+                LinearGradientPaint(
+                    0f,
+                    0f,
+                    width.toFloat(),
+                    height.toFloat(),
+                    fractions,
+                    colors.toTypedArray(),
+                )
+            }
         }
-
-        return LinearGradientPaint(
-            0f,
-            0f,
-            width.toFloat(),
-            height.toFloat(),
-            fractions,
-            colors.toTypedArray(),
-        )
     }
+
+    private fun themeSwatchPaint(): Paint = LinearGradientPaint(
+        0f,
+        0f,
+        width.toFloat(),
+        height.toFloat(),
+        floatArrayOf(0f, 1f),
+        arrayOf(
+            JBColor.PanelBackground,
+            JBColor.namedColor("Component.focusColor", JBColor.GRAY),
+        ),
+    )
 }

--- a/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughPaletteTest.kt
+++ b/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughPaletteTest.kt
@@ -11,7 +11,7 @@ class WalkthroughPaletteTest {
     @Test
     fun allPresetsAreAvailable() {
         assertEquals(
-            listOf("purple", "green", "blue", "red", "orange", "teal", "pink"),
+            listOf("idea", "purple", "green", "blue", "red", "orange", "teal", "pink"),
             WalkthroughPalettes.all.map(WalkthroughPalette::id),
         )
     }
@@ -24,8 +24,8 @@ class WalkthroughPaletteTest {
     }
 
     @Test
-    fun defaultPaletteIsPurple() {
-        assertSame(WalkthroughPalettes.PURPLE, WalkthroughPalettes.default)
+    fun defaultPaletteUsesIdeaStyling() {
+        assertSame(WalkthroughPalettes.IDEA, WalkthroughPalettes.default)
     }
 
     @Test
@@ -35,12 +35,12 @@ class WalkthroughPaletteTest {
 
     @Test
     fun lookupFallsBackToDefaultForUnknownId() {
-        assertSame(WalkthroughPalettes.PURPLE, WalkthroughPalettes.byId("unknown"))
+        assertSame(WalkthroughPalettes.IDEA, WalkthroughPalettes.byId("unknown"))
     }
 
     @Test
     fun lookupFallsBackToDefaultForMissingId() {
-        assertSame(WalkthroughPalettes.PURPLE, WalkthroughPalettes.byId(null))
+        assertSame(WalkthroughPalettes.IDEA, WalkthroughPalettes.byId(null))
     }
 
     @Test
@@ -84,5 +84,10 @@ class WalkthroughPaletteTest {
     @Test
     fun everyPresetHasSwatchColors() {
         assertTrue(WalkthroughPalettes.all.all { it.swatchGradientColors.isNotEmpty() })
+    }
+
+    @Test
+    fun ideaPaletteUsesTheCurrentIdeaTheme() {
+        assertTrue(WalkthroughPalettes.IDEA.isThemeBased)
     }
 }

--- a/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughPopupGeometryTest.kt
+++ b/src/test/kotlin/com/forketyfork/walkthrough/WalkthroughPopupGeometryTest.kt
@@ -3,6 +3,7 @@ package com.forketyfork.walkthrough
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import java.awt.geom.Point2D
 
 class WalkthroughPopupGeometryTest {
 
@@ -49,5 +50,16 @@ class WalkthroughPopupGeometryTest {
             val nextCycle = reverseLinearShift((t + period).toLong(), halfPeriod)
             assertEquals(first, nextCycle, 0.001f, "Expected periodicity at t=$t")
         }
+    }
+
+    @Test
+    fun connectorLineEndsAtArrowHeadBase() {
+        val arrowTip = Point2D.Float(100f, 50f)
+        val endControl = Point2D.Float(60f, 50f)
+
+        val lineEnd = connectorLineEnd(arrowTip, endControl)
+
+        assertEquals(87f, lineEnd.x, 0.001f)
+        assertEquals(50f, lineEnd.y, 0.001f)
     }
 }


### PR DESCRIPTION
## Issue

Walkthrough popups should look like regular IDEA overlays by default, follow the active appearance theme, and keep the connector arrow visually clean across all styles.

## Solution

The default popup style now resolves colors, typography, controls, and rounded corners from the active Jewel/IDEA theme while preserving the existing custom palettes. IDEA mode uses a static background, and Markdown content follows the same theme colors.

The connector stroke is 30% thinner, and its shaft ends at the arrowhead base rather than continuing to the tip. Settings, regression tests, and the changelog were updated accordingly.

## Context

No linked issue or pull request was provided.

## Test plan

- [ ] Open a walkthrough in light and dark IDEA themes and verify the popup follows the appearance theme.
- [ ] Verify the IDEA, custom palette, navigation, source, close, and question controls look correct.
- [ ] Show a walkthrough with a connector and verify the thinner line meets the arrowhead without a bulge.
- [ ] Open the plugin settings and verify IDEA is the default popup style while custom palettes remain available.
